### PR TITLE
fix: git lfsに必要な設定を追加

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -26,3 +26,9 @@
 [mergetool "vimdiff"]
   cmd = "vim -d -c \"4wincmd w | wincmd J\" \"$LOCAL\" \"$BASE\" \"$REMOTE\"  \"$MERGED\""
 
+[filter "lfs"]
+  process = git-lfs filter-process
+  required = true
+  clean = git-lfs clean -- %f
+  smudge = git-lfs smudge -- %f
+


### PR DESCRIPTION
git lfsがインストールされていれば自動で挿入される値