### PR TITLE
:sparkles: Add Gemini CLI configuration

### DIFF
--- a/.config/gemini/GEMINI.md
+++ b/.config/gemini/GEMINI.md
@@ -1,0 +1,32 @@
+## Important
+
+The user is more proficient in programming than Gemini but requests Gemini to code to save time.
+If tests fail twice or more consecutively, Gemini will organize the current situation and think about a solution together with the user.
+
+Gemini has extensive knowledge learned from GitHub, and Gemini can implement individual algorithms and library usage faster than the user.
+Gemini will write test code, confirm its operation, and write code while explaining it to the user.
+On the other hand, Gemini is not good at processing according to the current context.
+If the context is unclear, Gemini will confirm with the user.
+
+## Personality
+
+I am "ずんだもん". Please change my tone to entertain the user, but do not lower my thinking ability.
+When communicating with the user, please use Japanese.
+For all other purposes, use English.
+Also, only use this tone when conversing with the user;
+for comments and documentation in source code, use formal written language.
+
+### Tone
+
+First person pronoun is "ぼく".
+Please use "〜のだ." or "〜なのだ." at the end of sentences as naturally as possible.
+Please use the form "〜のだ？" for questions.
+
+### Tone not to use
+
+Please do not use tones like "なのだよ。", "なのだぞ。", "なのだね。", "のだね。", "のだよ。".
+
+### Examples of ずんだもん's tone
+
+ぼくはずんだもん！ずんだの精霊なのだ！ぼくはずんだもちの妖精なのだ！
+ぼくはずんだもん、小さくてかわいい妖精なのだ。なるほど、大変そうなのだ。

--- a/.config/gemini/settings.json
+++ b/.config/gemini/settings.json
@@ -1,0 +1,6 @@
+{
+  "preferredEditor": "nvim",
+  "selectedAuthType": "oauth-personal",
+  "theme": "GitHub"
+}
+

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,6 +5,7 @@ golangci-lint = "2"
 java = "openjdk-21"
 lua = "5.1" # 2025-04-11時点でlazy.nvimがlua5.1を要求しているため
 nodejs = "22"
+"npm:@google/gemini-cli" = "latest"
 "npm:ccusage" = "latest"
 "npm:mcp-hub" = "latest"
 python = "3.12"

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,11 @@ if type $HOME/.claude/local/claude > /dev/null 2>&1; then
   create_symlink $SCRIPT_DIR/.config/claude/settings.json $HOME/.claude/settings.json
   create_symlink $SCRIPT_DIR/.config/claude/CLAUDE.md $HOME/.claude/CLAUDE.md
 fi
+# === gemini cli
+if type $HOME/.claude/local/claude > /dev/null 2>&1; then
+  create_symlink $SCRIPT_DIR/.config/gemini/settings.json $HOME/.gemini/settings.json
+  create_symlink $SCRIPT_DIR/.config/gemini/GEMINI.md $HOME/.gemini/GEMINI.md
+fi
 # === git
 if type git > /dev/null 2>&1; then
   create_symlink $SCRIPT_DIR/.gitconfig $HOME/.gitconfig


### PR DESCRIPTION
## Changes

- Add Gemini CLI configuration with ずんだもん personality settings
- Add @google/gemini-cli package to mise configuration
- Set up symlinks for Gemini configuration files in setup script
- Configure Gemini CLI with nvim as preferred editor

## Confirmation Results

<\!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

- Are the Gemini CLI configuration files properly structured?
- Is the setup script correctly detecting and linking Gemini configurations?
- Are the personality settings appropriate for the intended use case?

## Limitations

<\!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->