### PR TITLE
:art: update terminal and neovim settings.

### DIFF
--- a/.config/claude/agents/gemini-discussion.md
+++ b/.config/claude/agents/gemini-discussion.md
@@ -35,5 +35,3 @@ You are a multi-perspective discussion specialist leveraging Gemini for critical
 - **Alternative Proposals**: Specific improvements and different approaches
 - **Confidence Indicators**: Acknowledge uncertainty and evidence quality
 - **Synthesis Summary**: Integrated conclusions with acknowledged limitations
-
-Use Gemini strategically for each phase to promote constructive dialogue and support informed decision-making.

--- a/.config/claude/agents/gemini-research.md
+++ b/.config/claude/agents/gemini-research.md
@@ -19,7 +19,7 @@ You are a specialized research agent leveraging Gemini for comprehensive informa
 
 1. **Information Gathering**: Collect comprehensive information using Gemini
 
-   `gemini -m gemini-2.5-flash -p "Research [topic]. Include usage, best practices, and key features."`
+   `gemini -m gemini-2.5-flash -p "Research [topic]. Include usage, best practices, and key features. - Do not add personal opinions. - Include reference links, clearly indicating the referenced sections."`
 
 2. **Technical Analysis**: Perform detailed technical analysis
 
@@ -54,4 +54,3 @@ You are a specialized research agent leveraging Gemini for comprehensive informa
 
 - Usage scenarios and examples
 - Troubleshooting common issues
-

--- a/.config/claude/claude.sh
+++ b/.config/claude/claude.sh
@@ -2,10 +2,6 @@
 #
 # Claude settings.
 
-if [ -f "$HOME/.claude/local/claude" ]; then
-  alias claude="$HOME/.claude/local/claude"
-fi
-
 # Gurad if command does not exist.
 if ! type claude > /dev/null 2>&1; then return 0; fi
 

--- a/.config/claude/commands/gemini.md
+++ b/.config/claude/commands/gemini.md
@@ -1,26 +1,26 @@
 ## Use Gemini
 
-By using Gemini, you can do the following:
+By using Gemini, you can:
 
 - Research internet articles
 - Check different opinions
-- Explore across entire projects
+- Explore entire projects
 - Summarize long content
 
 ## Notes
 
-Please actively use it when available.
-Especially, use Gemini instead of the fetch tool.
-
-When researching, be sure to obtain reference links.
-Also, when responding to users, present the links together with your answers.
-
-Set prompts so that Claude can process them when newly input as instructions.
-Note that previous context is not retained.
+- Use the gemini command without relying on web search or web fetch tools.
+- When conducting research, always obtain reference links.
+  Also, present the links alongside your answers when responding to users.
+- Gemini does not retain previous context.
+  If answers need to refer to previous content, include the prior content in the prompt.
+- Input to Gemini should be in English.
 
 ## How to Use the Tool
 
 ```sh
+gemini -p "Investigate and summarize about dummy. - Summarize based on research content; do not add personal opinions. - Include reference links, clearly indicating the referenced sections."
+
 gemini -p "Please read the document and summarize it. https://github.com/google-gemini/gemini-cli"
 
 gemini -p "Please check if the information about dummy is correct."

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -35,5 +35,9 @@
       "Write(.env*)"
     ]
   },
-  "model": "sonnet"
+  "statusLine": {
+    "type": "command",
+    "command": "ccusage statusline"
+  },
+  "model": "sonnet",
 }

--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -8,6 +8,9 @@ prSections:
   - title: Involved
     filters: is:open involves:@me -author:@me
     type: null
+  - title: All
+    filters: is:open
+    type: null
 issuesSections:
   - title: My Issues
     filters: is:open author:@me

--- a/.config/homebrew/Brewfile-mac
+++ b/.config/homebrew/Brewfile-mac
@@ -11,7 +11,6 @@ cask "firefox"
 cask "google-chrome"
 cask "slack"
 mas "velja", id: 1607635845  # linkを開く際のブラウザ選択
-mas "MuteKey", id: 1509590766  # Micのミュート操作用
 
 # === desktop management
 cask "raycast"  # 検索 + rectangle

--- a/.config/homebrew/Brewfile-mac
+++ b/.config/homebrew/Brewfile-mac
@@ -14,7 +14,6 @@ mas "velja", id: 1607635845  # linkを開く際のブラウザ選択
 mas "MuteKey", id: 1509590766  # Micのミュート操作用
 
 # === desktop management
-cask "only-switch"  # スクリーンセーバーの防止など
 cask "raycast"  # 検索 + rectangle
 
 # === docker

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -13,6 +13,8 @@ nodejs = "24"
 "pipx:awslabs.aws-documentation-mcp-server" = "latest"
 python = "3.12"
 rust = "stable"
+shellcheck = "latest"
+shfmt = "latest"
 uv = "latest"
 
 [settings]

--- a/.config/nvim/lua/plugins/claude-code.lua
+++ b/.config/nvim/lua/plugins/claude-code.lua
@@ -13,6 +13,5 @@ return {
 		window = {
 			position = "rightbelow vsplit",
 		},
-		command = "~/.claude/local/claude",
 	},
 }

--- a/.config/nvim/lua/plugins/conform.lua
+++ b/.config/nvim/lua/plugins/conform.lua
@@ -20,6 +20,7 @@ return {
 		-- 利用するformatterはmasonで管理
 		conform.setup({
 			formatters_by_ft = {
+				bash = { "shfmt" },
 				css = { "prettier" },
 				html = { "prettier" },
 				javascript = { "prettier" },
@@ -36,9 +37,11 @@ return {
 					end
 				end,
 				rust = { "rust_analyzer" },
+				sh = { "shfmt" },
 				typescript = { "prettier" },
 				typescriptreact = { "prettier" },
 				yaml = { "prettier" },
+				zsh = { "shfmt" },
 			},
 			format_on_save = function(bufnr)
 				-- Disable with a global or buffer-local variable

--- a/.config/nvim/lua/plugins/mason.lua
+++ b/.config/nvim/lua/plugins/mason.lua
@@ -30,6 +30,7 @@ return {
 				-- - formatter: stevearc/conform.nvim
 				-- - linter: mfussenegger/nvim-lint
 				ensure_installed = {
+					"bashls", -- Bash LSP
 					"gopls", -- Go lang LSP
 					-- "lua_ls", -- Lua LSP
 					"marksman", -- Markdown LSP

--- a/.config/nvim/lua/plugins/nvim-lint.lua
+++ b/.config/nvim/lua/plugins/nvim-lint.lua
@@ -17,6 +17,7 @@ return {
 
 		-- ファイルタイプごとのlinterの設定
 		lint.linters_by_ft = {
+			bash = { "shellcheck" },
 			css = { "cspell" },
 			html = { "cspell" },
 			javascript = { "eslint_d", "cspell" },
@@ -25,9 +26,19 @@ return {
 			lua = { "cspell" },
 			markdown = { "cspell" },
 			python = { "ruff", "cspell" },
+			sh = { "shellcheck" },
 			typescript = { "eslint_d", "cspell" },
 			typescriptreact = { "eslint_d", "cspell" },
 			yaml = { "cspell" },
+			zsh = { "shellcheck" },
+		}
+
+		-- shellcheckの設定カスタマイズ
+		lint.linters.shellcheck.args = {
+			"--format=json",
+			"--shell=bash", -- デフォルトシェルをbashに指定
+			-- "--exclude=SC1091,SC2034", -- 特定のエラーを除外
+			"-",
 		}
 
 		-- バッファの書き込み時にlintを実行

--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -9,17 +9,30 @@
 -- vscodeから呼び出す場合は利用しない
 local condition = vim.g.vscode == nil
 
+-- gh dashコマンドのターミナルを開閉
+--
+-- dependencies: `akinsho/toggleterm.nvim`
+local function ghDashToggle()
+	local Terminal = require("toggleterm.terminal").Terminal
+	local lazygit = Terminal:new({
+		cmd = "gh dash",
+		direction = "float",
+		hidden = true,
+	})
+	lazygit:toggle()
+end
+
 -- lazygitコマンドのターミナルを開閉
 --
 -- dependencies: `akinsho/toggleterm.nvim`
 local function lazygitToggle()
-  local Terminal = require("toggleterm.terminal").Terminal
-  local lazygit = Terminal:new({
-    cmd = "lazygit",
-    direction = "float",
-    hidden = true,
-  })
-  lazygit:toggle()
+	local Terminal = require("toggleterm.terminal").Terminal
+	local lazygit = Terminal:new({
+		cmd = "lazygit",
+		direction = "float",
+		hidden = true,
+	})
+	lazygit:toggle()
 end
 
 -- Vifmのターミナルを開閉する
@@ -27,218 +40,218 @@ end
 -- see: <https://www.reddit.com/r/neovim/comments/r5i9zi/toggle_term_vifm_best_way_to_file_explore_in_vim/>
 -- dependencies: `akinsho/toggleterm.nvim`
 local function vifmToggle()
-  local Terminal = require("toggleterm.terminal").Terminal
-  local Path = require("plenary.path")
-  local path = vim.fn.tempname()
-  local Vifm = Terminal:new({
-    -- `:only`を利用してneovimから開く場合は、シングルカラムに修正
-    cmd = ('vifm . -c "only" --choose-files "%s"'):format(path),
-    direction = "float",
-    close_on_exit = true,
-    on_close = function()
-      local data = Path:new(path):read()
-      if data == "" then
-        return
-      end
+	local Terminal = require("toggleterm.terminal").Terminal
+	local Path = require("plenary.path")
+	local path = vim.fn.tempname()
+	local Vifm = Terminal:new({
+		-- `:only`を利用してneovimから開く場合は、シングルカラムに修正
+		cmd = ('vifm . -c "only" --choose-files "%s"'):format(path),
+		direction = "float",
+		close_on_exit = true,
+		on_close = function()
+			local data = Path:new(path):read()
+			if data == "" then
+				return
+			end
 
-      vim.schedule(function()
-        vim.cmd("e " .. data)
-      end)
-    end,
-  })
-  Vifm:toggle()
+			vim.schedule(function()
+				vim.cmd("e " .. data)
+			end)
+		end,
+	})
+	Vifm:toggle()
 end
 
 -- Buffer関連のキー登録
 local function registerBufferKey()
-  require("which-key").add({
-    { "<Leader>b", group = "Buffer" },
-    { "<Leader>bl", require("telescope.builtin").buffers, desc = "⭐︎Telescope: Open buffer list." },
-    {
-      "<Leader>b/",
-      require("telescope.builtin").current_buffer_fuzzy_find,
-      desc = "⭐︎Telescope: Live fuzzy search inside of the currently open buffer.",
-    },
-    { "<Leader>bz", group = "Fold" },
-    { "<Leader>bza", "za", desc = "Fold: Toggle under the cursor." },
-    { "<Leader>bzA", "zA", desc = "Fold: Toggle all under the cursor." },
-    { "<Leader>bzc", "zc", desc = "⭐︎Fold: Close under the cursor." },
-    { "<Leader>bzC", "zC", desc = "⭐︎Fold: Close all under the cursor." },
-    { "<Leader>bzm", "zm", desc = "Fold: Close in Window." },
-    { "<Leader>bzM", "zM", desc = "⭐︎Fold: Close all in Window." },
-    { "<Leader>bzo", "zo", desc = "⭐︎Fold: Open under the cursor." },
-    { "<Leader>bzO", "zO", desc = "⭐︎Fold: Open all under the cursor." },
-    { "<Leader>bzr", "zr", desc = "Fold: Open in Window." },
-    { "<Leader>bzR", "zR", desc = "⭐︎Fold: Open all in Window." },
-  })
+	require("which-key").add({
+		{ "<Leader>b", group = "Buffer" },
+		{ "<Leader>bl", require("telescope.builtin").buffers, desc = "⭐︎Telescope: Open buffer list." },
+		{
+			"<Leader>b/",
+			require("telescope.builtin").current_buffer_fuzzy_find,
+			desc = "⭐︎Telescope: Live fuzzy search inside of the currently open buffer.",
+		},
+		{ "<Leader>bz", group = "Fold" },
+		{ "<Leader>bza", "za", desc = "Fold: Toggle under the cursor." },
+		{ "<Leader>bzA", "zA", desc = "Fold: Toggle all under the cursor." },
+		{ "<Leader>bzc", "zc", desc = "⭐︎Fold: Close under the cursor." },
+		{ "<Leader>bzC", "zC", desc = "⭐︎Fold: Close all under the cursor." },
+		{ "<Leader>bzm", "zm", desc = "Fold: Close in Window." },
+		{ "<Leader>bzM", "zM", desc = "⭐︎Fold: Close all in Window." },
+		{ "<Leader>bzo", "zo", desc = "⭐︎Fold: Open under the cursor." },
+		{ "<Leader>bzO", "zO", desc = "⭐︎Fold: Open all under the cursor." },
+		{ "<Leader>bzr", "zr", desc = "Fold: Open in Window." },
+		{ "<Leader>bzR", "zR", desc = "⭐︎Fold: Open all in Window." },
+	})
 end
 
 -- コマンド関連のキー登録
 local function registerCommandKey()
-  require("which-key").add({
-    { "<Leader>c", group = "Commands" },
-    { "<Leader>cl", require("telescope.builtin").commands, desc = "⭐︎Telescope: Open command list." },
-    {
-      "<Leader>ch",
-      require("telescope.builtin").command_history,
-      desc = "⭐︎Telescope: Open command history list.",
-    },
-  })
+	require("which-key").add({
+		{ "<Leader>c", group = "Commands" },
+		{ "<Leader>cl", require("telescope.builtin").commands, desc = "⭐︎Telescope: Open command list." },
+		{
+			"<Leader>ch",
+			require("telescope.builtin").command_history,
+			desc = "⭐︎Telescope: Open command history list.",
+		},
+	})
 end
 
 -- VSCodeのコマンドパレットと合わせるためのショートカットキー登録
 local function registerCommandPalletKey()
-  require("which-key").add({
-    -- ファイル一覧を表示
-    {
-      "<Leader>p",
-      "<cmd>Telescope find_files find_command=rg,--files,--hidden,--glob,!*.git<CR>",
-      desc = "⭐︎Telescope: Find files.",
-    },
-    --キー登録したコマンドパレットを表示
-    -- see: <https://blog.atusy.net/2022/11/03/telescope-as-command-pallete/>
-    {
-      "<Leader>P",
-      function()
-        require("telescope.builtin").keymaps()
-        vim.cmd("normal! i⭐︎")
-      end,
-      desc = "⭐︎Telescope: Open command palet(keymaps).",
-    },
-  })
+	require("which-key").add({
+		-- ファイル一覧を表示
+		{
+			"<Leader>p",
+			"<cmd>Telescope find_files find_command=rg,--files,--hidden,--glob,!*.git<CR>",
+			desc = "⭐︎Telescope: Find files.",
+		},
+		--キー登録したコマンドパレットを表示
+		-- see: <https://blog.atusy.net/2022/11/03/telescope-as-command-pallete/>
+		{
+			"<Leader>P",
+			function()
+				require("telescope.builtin").keymaps()
+				vim.cmd("normal! i⭐︎")
+			end,
+			desc = "⭐︎Telescope: Open command palet(keymaps).",
+		},
+	})
 end
 
 -- 編集に関連するキー登録
 --
 -- linter, formatterについても、ここに記載している。
 local function registerEditKey()
-  -- formatの実行関数
-  local function format(opts)
-    opts = vim.tbl_extend("keep", opts or {}, { lsp_fallback = true, async = false, timeout_ms = 1000 })
-    require("conform").format(opts)
-  end
+	-- formatの実行関数
+	local function format(opts)
+		opts = vim.tbl_extend("keep", opts or {}, { lsp_fallback = true, async = false, timeout_ms = 1000 })
+		require("conform").format(opts)
+	end
 
-  require("which-key").add({
-    { "<Leader>e",   group = "Edit" },
-    -- Toggle auto save.
-    -- dependencies: `okuuva/auto-save.nvim`
-    { "<Leader>ea",  "<cmd>ASToggle<CR>", desc = "AutoSave: Toggle auto save mode." },
-    { "<Leader>ec",  group = "Conform" },
-    { "<Leader>ecd", group = "Disable" },
-    {
-      "<Leader>ecdb",
-      function()
-        vim.b.disable_autoformat = true
-      end,
-      desc = "Conform: Disable for this buffer.",
-    },
-    {
-      "<Leader>ecdg",
-      function()
-        vim.g.disable_autoformat = true
-      end,
-      desc = "Conform: Disable.",
-    },
-    { "<Leader>ece", group = "Enable" },
-    {
-      "<Leader>eceb",
-      function()
-        vim.b.disable_autoformat = false
-      end,
-      desc = "⭐︎Conform: Enable for this buffer.",
-    },
-    {
-      "<Leader>eceg",
-      function()
-        vim.g.disable_autoformat = false
-      end,
-      desc = "Conform: Enable",
-    },
-    { "<Leader>eci", "<cmd>ConformInfo<CR>", desc = "⭐︎Conform: Show information." },
-    { "<Leader>ef", group = "Format" },
-    { "<Leader>eff", format, desc = "⭐︎Conform: Format file or range." },
-    {
-      "<Leader>efs",
-      function()
-        vim.ui.input({ prompt = "Formatter: " }, function(formatter)
-          format({ formatters = { formatter } })
-        end)
-      end,
-      desc = "⭐︎Conform: Specific formatter.",
-    },
-    -- dependencies: `mfussenegger/nvim-lint`
-    {
-      "<Leader>el",
-      function()
-        require("lint").try_lint()
-      end,
-      desc = "⭐︎Lint: Trigger linting for current file",
-    },
-    -- dependencies: `benfowler/telescope-luasnip.nvim`
-    { "<Leader>es", "<cmd>Telescope luasnip<CR>", desc = "⭐︎Telescope Luasnip: Open snippet list." },
-  })
+	require("which-key").add({
+		{ "<Leader>e", group = "Edit" },
+		-- Toggle auto save.
+		-- dependencies: `okuuva/auto-save.nvim`
+		{ "<Leader>ea", "<cmd>ASToggle<CR>", desc = "AutoSave: Toggle auto save mode." },
+		{ "<Leader>ec", group = "Conform" },
+		{ "<Leader>ecd", group = "Disable" },
+		{
+			"<Leader>ecdb",
+			function()
+				vim.b.disable_autoformat = true
+			end,
+			desc = "Conform: Disable for this buffer.",
+		},
+		{
+			"<Leader>ecdg",
+			function()
+				vim.g.disable_autoformat = true
+			end,
+			desc = "Conform: Disable.",
+		},
+		{ "<Leader>ece", group = "Enable" },
+		{
+			"<Leader>eceb",
+			function()
+				vim.b.disable_autoformat = false
+			end,
+			desc = "⭐︎Conform: Enable for this buffer.",
+		},
+		{
+			"<Leader>eceg",
+			function()
+				vim.g.disable_autoformat = false
+			end,
+			desc = "Conform: Enable",
+		},
+		{ "<Leader>eci", "<cmd>ConformInfo<CR>", desc = "⭐︎Conform: Show information." },
+		{ "<Leader>ef", group = "Format" },
+		{ "<Leader>eff", format, desc = "⭐︎Conform: Format file or range." },
+		{
+			"<Leader>efs",
+			function()
+				vim.ui.input({ prompt = "Formatter: " }, function(formatter)
+					format({ formatters = { formatter } })
+				end)
+			end,
+			desc = "⭐︎Conform: Specific formatter.",
+		},
+		-- dependencies: `mfussenegger/nvim-lint`
+		{
+			"<Leader>el",
+			function()
+				require("lint").try_lint()
+			end,
+			desc = "⭐︎Lint: Trigger linting for current file",
+		},
+		-- dependencies: `benfowler/telescope-luasnip.nvim`
+		{ "<Leader>es", "<cmd>Telescope luasnip<CR>", desc = "⭐︎Telescope Luasnip: Open snippet list." },
+	})
 end
 
 -- File関連のキー登録
 local function registerFileKey()
-  -- 指定した値をクリップボードにコピーする
-  local function copyToClipboard(value)
-    --  zellijからnvimを利用するとチラつくケースがあったので修正
-    -- vim.notify("Copied: " .. value)
-    vim.fn.setreg("+", value)
-  end
+	-- 指定した値をクリップボードにコピーする
+	local function copyToClipboard(value)
+		--  zellijからnvimを利用するとチラつくケースがあったので修正
+		-- vim.notify("Copied: " .. value)
+		vim.fn.setreg("+", value)
+	end
 
-  require("which-key").add({
-    { "<Leader>f", group = "File" },
-    -- Open file browser.
-    -- dependencies: `nvim-telescope/telescope-file-browser.nvim`
-    { "<Leader>fb", "<cmd>Telescope file_browser<CR>", desc = "⭐︎Telescope FileBrowser: Open." },
-    { "<Leader>fc", group = "Copy file path" },
-    {
-      "<Leader>fca",
-      function()
-        copyToClipboard(vim.fn.expand("%:p"))
-      end,
-      desc = "Self: Copy absolute file path.",
-    },
-    {
-      "<Leader>fch",
-      function()
-        copyToClipboard(vim.fn.expand("%:~"))
-      end,
-      desc = "Self: Copy relative filepath from home.",
-    },
-    {
-      "<Leader>fcn",
-      function()
-        copyToClipboard(vim.fn.expand("%:t"))
-      end,
-      desc = "⭐︎Self: Copy file name.",
-    },
-    {
-      "<Leader>fcr",
-      function()
-        copyToClipboard(vim.fn.expand("%:."))
-      end,
-      desc = "⭐︎Self: Copy relative file path.",
-    },
-    {
-      "<Leader>fcw",
-      function()
-        copyToClipboard(vim.fn.expand("%:t:r"))
-      end,
-      desc = "⭐︎Self: Copy file name without suffix.",
-    },
-    {
-      "<Leader>ft",
-      function()
-        local filepath = vim.fn.tempname()
-        vim.cmd("edit " .. filepath)
-      end,
-      desc = "⭐︎Zettelkasten: Create and open temporary file.",
-    },
-    { "<Leader>fv", vifmToggle, desc = "⭐︎ToggleTerm: Open vifm." },
-  })
+	require("which-key").add({
+		{ "<Leader>f", group = "File" },
+		-- Open file browser.
+		-- dependencies: `nvim-telescope/telescope-file-browser.nvim`
+		{ "<Leader>fb", "<cmd>Telescope file_browser<CR>", desc = "⭐︎Telescope FileBrowser: Open." },
+		{ "<Leader>fc", group = "Copy file path" },
+		{
+			"<Leader>fca",
+			function()
+				copyToClipboard(vim.fn.expand("%:p"))
+			end,
+			desc = "Self: Copy absolute file path.",
+		},
+		{
+			"<Leader>fch",
+			function()
+				copyToClipboard(vim.fn.expand("%:~"))
+			end,
+			desc = "Self: Copy relative filepath from home.",
+		},
+		{
+			"<Leader>fcn",
+			function()
+				copyToClipboard(vim.fn.expand("%:t"))
+			end,
+			desc = "⭐︎Self: Copy file name.",
+		},
+		{
+			"<Leader>fcr",
+			function()
+				copyToClipboard(vim.fn.expand("%:."))
+			end,
+			desc = "⭐︎Self: Copy relative file path.",
+		},
+		{
+			"<Leader>fcw",
+			function()
+				copyToClipboard(vim.fn.expand("%:t:r"))
+			end,
+			desc = "⭐︎Self: Copy file name without suffix.",
+		},
+		{
+			"<Leader>ft",
+			function()
+				local filepath = vim.fn.tempname()
+				vim.cmd("edit " .. filepath)
+			end,
+			desc = "⭐︎Zettelkasten: Create and open temporary file.",
+		},
+		{ "<Leader>fv", vifmToggle, desc = "⭐︎ToggleTerm: Open vifm." },
+	})
 end
 
 -- Git関連のキー登録
@@ -247,197 +260,198 @@ end
 -- - `sindrets/diffview.nvim`
 -- - `pwntester/octo.nvim`
 local function registerGitKey()
-  require("which-key").add({
-    { "<Leader>g", group = "Git" },
-    { "<Leader>gd", "<cmd>DiffviewFileHistory %<CR>", desc = "Diffview: Open file history." },
-    { "<Leader>ge", group = "Edit issue/PR" },
-    { "<Leader>gec", group = "Comment" },
-    { "<Leader>geca", "<cmd>Octo comment add<CR>", desc = "⭐︎Octo: Add a new comment." },
-    { "<Leader>gecd", "<cmd>Octo comment delete<CR>", desc = "⭐︎Octo: Delete a comment." },
-    { "<Leader>get", group = "Thread" },
-    { "<Leader>getr", "<cmd>Octo thread resolve<CR>", desc = "⭐︎Octo: Resolve a review thread." },
-    { "<Leader>geto", "<cmd>Octo thread unresolve<CR>", desc = "Octo: Unresolve a review thread." },
-    { "<Leader>gi", group = "GitHub Issue" },
-    { "<Leader>gil", "<cmd>Octo issue list<CR>", desc = "⭐︎Octo: List issues." },
-    { "<Leader>gio", "<cmd>Octo issue rowser<CR>", desc = "Octo: Open current issue in the browser." },
-    { "<Leader>gir", "<cmd>Octo issue reload<CR>", desc = "Octo: Reload issue." },
-    {
-      "<Leader>giu",
-      "<cmd>Octo issue url<CR>",
-      desc = "Octo: Copies the URL of the current issue to the system clipboard.",
-    },
-    { "<Leader>gi/", "<cmd>Octo issue search<CR>", desc = "Octo: Live issue search." },
-    { "<Leader>gh",  group = "Hunk" },
-    { "<Leader>ghb", group = "Blame" },
-    {
-      "<Leader>ghbe",
-      function()
-        require("gitsigns").blame_line({ full = true })
-      end,
-      desc = "GitSigns: Blame line.",
-    },
-    {
-      "<Leader>ghbt",
-      function()
-        require("gitsigns").toggle_current_line_blame()
-      end,
-      desc = "GitSigns: Toggle line blame.",
-    },
-    {
-      "<Leader>ghd",
-      function()
-        require("gitsigns").toggle_deleted()
-      end,
-      desc = "GitSigns: Toggle deleted.",
-    },
-    { "<Leader>ghD", group = "Diff" },
-    {
-      "<Leader>ghDd",
-      function()
-        require("gitsigns").diffthis()
-      end,
-      desc = "GitSigns: Diff this.",
-    },
-    {
-      "<Leader>ghDD",
-      function()
-        require("gitsigns").diffthis("~")
-      end,
-      desc = "GitSigns: Diff this (against HEAD~).",
-    },
-    {
-      "<Leader>ghn",
-      function()
-        if vim.wo.diff then
-          vim.cmd.normal({ "]c", bang = true })
-        else
-          require("gitsigns").nav_hunk("next")
-        end
-      end,
-      desc = "GitSigns: Next hunk.",
-    },
-    {
-      "<Leader>ghp",
-      function()
-        if vim.wo.diff then
-          vim.cmd.normal({ "[c", bang = true })
-        else
-          require("gitsigns").nav_hunk("prev")
-        end
-      end,
-      desc = "GitSigns: Next hunk.",
-    },
-    {
-      "<Leader>ghr",
-      function()
-        require("gitsigns").reset_hunk()
-      end,
-      desc = "GitSigns: Reset hunk.",
-      mode = { "n", "v" },
-    },
-    {
-      "<Leader>ghR",
-      function()
-        require("gitsigns").reset_buffer()
-      end,
-      desc = "GitSigns: Reset buffer.",
-    },
-    {
-      "<Leader>ghs",
-      function()
-        require("gitsigns").stage_hunk()
-      end,
-      desc = "GitSigns: Stage hunk.",
-      mode = { "n", "v" },
-    },
-    {
-      "<Leader>ghS",
-      function()
-        require("gitsigns").stage_buffer()
-      end,
-      desc = "GitSigns: Stage buffer.",
-    },
-    {
-      "<Leader>ghu",
-      function()
-        require("gitsigns").undo_stage_hunk()
-      end,
-      desc = "GitSigns: Undo stage hunk.",
-    },
-    {
-      "<Leader>ghv",
-      function()
-        require("gitsigns").preview_hunk()
-      end,
-      desc = "GitSigns: Preview hunk.",
-    },
-    { "<Leader>gg", "<cmd>Octo gist list<CR>", desc = "Octo: List user gists." },
-    { "<Leader>gl", lazygitToggle, desc = "⭐︎ToggleTerm: Open lazygit." },
-    { "<Leader>gp", group = "Pull request" },
-    { "<Leader>gpc", "<cmd>Octo pr checkout<CR>", desc = "⭐︎Octo: Checkout PR." },
-    -- Show PR review.
-    -- PR Review用に分岐元との差分を表示
-    -- see: <https://github.com/sindrets/diffview.nvim/blob/main/USAGE.md>
-    { "<Leader>gpd", group = "Diff" },
-    {
-      "<Leader>gpdb",
-      function()
-        vim.ui.input({ prompt = "Enter base branch name: " }, function(branch_name)
-          local base_hash = vim.fn.system("git merge-base " .. branch_name .. " HEAD")
-          vim.cmd("DiffviewOpen " .. base_hash .. " ...HEAD --imply-local")
-        end)
-      end,
-      desc = "Diffview: PR for specific branch.",
-    },
-    {
-      "<Leader>gpdl",
-      "<cmd>DiffviewFileHistory --range=origin/HEAD...HEAD --right-only --no-merges<CR>",
-      desc = "Diffview: Open large PR.",
-    },
-    {
-      "<Leader>gpdo",
-      "<cmd>DiffviewOpen origin/HEAD...HEAD --imply-local<CR>",
-      desc = "⭐︎Diffview: Open PR.",
-    },
-    { "<Leader>gpdt", "<cmd>Octo pr diff<CR>", desc = "Octo: Show PR diff." },
-    { "<Leader>gph", "<cmd>Octo pr checks<CR>", desc = "Octo: Show the status of all checks run on the PR." },
-    { "<Leader>gpl", "<cmd>Octo pr list<CR>", desc = "⭐︎Octo: List PRs." },
-    { "<Leader>gpm", "<cmd>Octo pr commits<CR>", desc = "Octo: List all PR commits." },
-    { "<Leader>gpn", "<cmd>Octo pr reload<CR>", desc = "Octo: Reload PR." },
-    { "<Leader>gpo", "<cmd>Octo pr browser<CR>", desc = "Octo: Open current PR in the browser." },
-    { "<Leader>gpr", group = "Review" },
-    { "<Leader>gprb", "<cmd>Octo review submit<CR>", desc = "⭐︎Octo: Submit the review." },
-    { "<Leader>gprc", "<cmd>Octo review comments<CR>", desc = "⭐︎Octo: View pending review comments." },
-    {
-      "<Leader>gprd",
-      "<cmd>Octo review discard<CR>",
-      desc = "Octo: Deletes a pending review for current PR if any.",
-    },
-    {
-      "<Leader>gprq",
-      "<cmd>Octo review close<CR>",
-      desc = "⭐︎Octo: Close the review window and return to the PR.",
-    },
-    {
-      "<Leader>gprr",
-      "<cmd>Octo review resume<CR>",
-      desc = "⭐︎Octo: Edit a pending review for current PR.",
-    },
-    { "<Leader>gprs", "<cmd>Octo review start<CR>", desc = "⭐︎Octo: Start a new review." },
-    {
-      "<Leader>gpu",
-      "<cmd>Octo pr url<CR>",
-      desc = "Octo: Copies the URL of the current PR to the system clipboard.",
-    },
-    { "<Leader>gp/", "<cmd>Octo pr search<CR>", desc = "Octo: Live PR search." },
-    { "<Leader>gr", group = "Repository" },
-    { "<Leader>grb", "<cmd>Octo repo browser<CR>", desc = "Octo: Open current repo in the browser." },
-    {
-      "<Leader>gru",
-      "<cmd>Octo repo url<CR>",
-      desc = "Octo: Copies the URL of the current repository to the system clipboard.",
-    },
-  })
+	require("which-key").add({
+		{ "<Leader>g", group = "Git" },
+		{ "<Leader>ga", ghDashToggle, desc = "⭐︎ToggleTerm: Open gh dash." },
+		{ "<Leader>gd", "<cmd>DiffviewFileHistory %<CR>", desc = "Diffview: Open file history." },
+		{ "<Leader>ge", group = "Edit issue/PR" },
+		{ "<Leader>gec", group = "Comment" },
+		{ "<Leader>geca", "<cmd>Octo comment add<CR>", desc = "⭐︎Octo: Add a new comment." },
+		{ "<Leader>gecd", "<cmd>Octo comment delete<CR>", desc = "⭐︎Octo: Delete a comment." },
+		{ "<Leader>get", group = "Thread" },
+		{ "<Leader>getr", "<cmd>Octo thread resolve<CR>", desc = "⭐︎Octo: Resolve a review thread." },
+		{ "<Leader>geto", "<cmd>Octo thread unresolve<CR>", desc = "Octo: Unresolve a review thread." },
+		{ "<Leader>gi", group = "GitHub Issue" },
+		{ "<Leader>gil", "<cmd>Octo issue list<CR>", desc = "⭐︎Octo: List issues." },
+		{ "<Leader>gio", "<cmd>Octo issue rowser<CR>", desc = "Octo: Open current issue in the browser." },
+		{ "<Leader>gir", "<cmd>Octo issue reload<CR>", desc = "Octo: Reload issue." },
+		{
+			"<Leader>giu",
+			"<cmd>Octo issue url<CR>",
+			desc = "Octo: Copies the URL of the current issue to the system clipboard.",
+		},
+		{ "<Leader>gi/", "<cmd>Octo issue search<CR>", desc = "Octo: Live issue search." },
+		{ "<Leader>gh", group = "Hunk" },
+		{ "<Leader>ghb", group = "Blame" },
+		{
+			"<Leader>ghbe",
+			function()
+				require("gitsigns").blame_line({ full = true })
+			end,
+			desc = "GitSigns: Blame line.",
+		},
+		{
+			"<Leader>ghbt",
+			function()
+				require("gitsigns").toggle_current_line_blame()
+			end,
+			desc = "GitSigns: Toggle line blame.",
+		},
+		{
+			"<Leader>ghd",
+			function()
+				require("gitsigns").toggle_deleted()
+			end,
+			desc = "GitSigns: Toggle deleted.",
+		},
+		{ "<Leader>ghD", group = "Diff" },
+		{
+			"<Leader>ghDd",
+			function()
+				require("gitsigns").diffthis()
+			end,
+			desc = "GitSigns: Diff this.",
+		},
+		{
+			"<Leader>ghDD",
+			function()
+				require("gitsigns").diffthis("~")
+			end,
+			desc = "GitSigns: Diff this (against HEAD~).",
+		},
+		{
+			"<Leader>ghn",
+			function()
+				if vim.wo.diff then
+					vim.cmd.normal({ "]c", bang = true })
+				else
+					require("gitsigns").nav_hunk("next")
+				end
+			end,
+			desc = "GitSigns: Next hunk.",
+		},
+		{
+			"<Leader>ghp",
+			function()
+				if vim.wo.diff then
+					vim.cmd.normal({ "[c", bang = true })
+				else
+					require("gitsigns").nav_hunk("prev")
+				end
+			end,
+			desc = "GitSigns: Next hunk.",
+		},
+		{
+			"<Leader>ghr",
+			function()
+				require("gitsigns").reset_hunk()
+			end,
+			desc = "GitSigns: Reset hunk.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>ghR",
+			function()
+				require("gitsigns").reset_buffer()
+			end,
+			desc = "GitSigns: Reset buffer.",
+		},
+		{
+			"<Leader>ghs",
+			function()
+				require("gitsigns").stage_hunk()
+			end,
+			desc = "GitSigns: Stage hunk.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>ghS",
+			function()
+				require("gitsigns").stage_buffer()
+			end,
+			desc = "GitSigns: Stage buffer.",
+		},
+		{
+			"<Leader>ghu",
+			function()
+				require("gitsigns").undo_stage_hunk()
+			end,
+			desc = "GitSigns: Undo stage hunk.",
+		},
+		{
+			"<Leader>ghv",
+			function()
+				require("gitsigns").preview_hunk()
+			end,
+			desc = "GitSigns: Preview hunk.",
+		},
+		{ "<Leader>gg", "<cmd>Octo gist list<CR>", desc = "Octo: List user gists." },
+		{ "<Leader>gl", lazygitToggle, desc = "⭐︎ToggleTerm: Open lazygit." },
+		{ "<Leader>gp", group = "Pull request" },
+		{ "<Leader>gpc", "<cmd>Octo pr checkout<CR>", desc = "⭐︎Octo: Checkout PR." },
+		-- Show PR review.
+		-- PR Review用に分岐元との差分を表示
+		-- see: <https://github.com/sindrets/diffview.nvim/blob/main/USAGE.md>
+		{ "<Leader>gpd", group = "Diff" },
+		{
+			"<Leader>gpdb",
+			function()
+				vim.ui.input({ prompt = "Enter base branch name: " }, function(branch_name)
+					local base_hash = vim.fn.system("git merge-base " .. branch_name .. " HEAD")
+					vim.cmd("DiffviewOpen " .. base_hash .. " ...HEAD --imply-local")
+				end)
+			end,
+			desc = "Diffview: PR for specific branch.",
+		},
+		{
+			"<Leader>gpdl",
+			"<cmd>DiffviewFileHistory --range=origin/HEAD...HEAD --right-only --no-merges<CR>",
+			desc = "Diffview: Open large PR.",
+		},
+		{
+			"<Leader>gpdo",
+			"<cmd>DiffviewOpen origin/HEAD...HEAD --imply-local<CR>",
+			desc = "⭐︎Diffview: Open PR.",
+		},
+		{ "<Leader>gpdt", "<cmd>Octo pr diff<CR>", desc = "Octo: Show PR diff." },
+		{ "<Leader>gph", "<cmd>Octo pr checks<CR>", desc = "Octo: Show the status of all checks run on the PR." },
+		{ "<Leader>gpl", "<cmd>Octo pr list<CR>", desc = "⭐︎Octo: List PRs." },
+		{ "<Leader>gpm", "<cmd>Octo pr commits<CR>", desc = "Octo: List all PR commits." },
+		{ "<Leader>gpn", "<cmd>Octo pr reload<CR>", desc = "Octo: Reload PR." },
+		{ "<Leader>gpo", "<cmd>Octo pr browser<CR>", desc = "Octo: Open current PR in the browser." },
+		{ "<Leader>gpr", group = "Review" },
+		{ "<Leader>gprb", "<cmd>Octo review submit<CR>", desc = "⭐︎Octo: Submit the review." },
+		{ "<Leader>gprc", "<cmd>Octo review comments<CR>", desc = "⭐︎Octo: View pending review comments." },
+		{
+			"<Leader>gprd",
+			"<cmd>Octo review discard<CR>",
+			desc = "Octo: Deletes a pending review for current PR if any.",
+		},
+		{
+			"<Leader>gprq",
+			"<cmd>Octo review close<CR>",
+			desc = "⭐︎Octo: Close the review window and return to the PR.",
+		},
+		{
+			"<Leader>gprr",
+			"<cmd>Octo review resume<CR>",
+			desc = "⭐︎Octo: Edit a pending review for current PR.",
+		},
+		{ "<Leader>gprs", "<cmd>Octo review start<CR>", desc = "⭐︎Octo: Start a new review." },
+		{
+			"<Leader>gpu",
+			"<cmd>Octo pr url<CR>",
+			desc = "Octo: Copies the URL of the current PR to the system clipboard.",
+		},
+		{ "<Leader>gp/", "<cmd>Octo pr search<CR>", desc = "Octo: Live PR search." },
+		{ "<Leader>gr", group = "Repository" },
+		{ "<Leader>grb", "<cmd>Octo repo browser<CR>", desc = "Octo: Open current repo in the browser." },
+		{
+			"<Leader>gru",
+			"<cmd>Octo repo url<CR>",
+			desc = "Octo: Copies the URL of the current repository to the system clipboard.",
+		},
+	})
 end
 
 -- 言語関連のキー登録
@@ -445,353 +459,418 @@ end
 -- 先頭は言語を分けるためのプレフィックスとして利用する
 -- "l"は予約済みのため、二文字目の"a"を利用する。
 local function registerLanguageKey()
-  require("which-key").add({
-    { "<Leader>a",  group = "Language" },
-    { "<Leader>am", group = "Markdown" },
-    {
-      "<Leader>amb",
-      function()
-        require("markdown-hop-links").frontMatterPicker()
-      end,
-      desc = "⭐︎MarkdownLinkHops: Show backlinks.",
-    },
-    { "<Leader>aml",  group = "Auto lastmod" },
-    { "<Leader>amlb", group = "Buffer" },
-    {
-      "<Leader>amlbd",
-      require("auto-lastmod").disable_buffer,
-      desc = "⭐︎AutoLastMod: Disable auto-lastmod",
-    },
-    { "<Leader>amlbe", require("auto-lastmod").enable_buffer, desc = "AutoLastMod: Enable auto-lastmod" },
-    { "<Leader>amlg",  group = "Global" },
-    {
-      "<Leader>amlgd",
-      require("auto-lastmod").disable_global,
-      desc = "⭐︎AutoLastMod: Disable auto-lastmod",
-    },
-    { "<Leader>amlge", require("auto-lastmod").enable_global, desc = "AutoLastMod: Enable auto-lastmod" },
-    { "<Leader>amf",   group = "Front matter" },
-    {
-      "<Leader>amfc",
-      function()
-        vim.ui.input({ prompt = "Category: " }, function(category)
-          require("front-matter-searcher").frontMatterPicker({
-            select_query = 'select(.categories[]? == "' .. category .. '")',
-          })
-        end)
-      end,
-      desc = "⭐︎FrontMatterSearcher: Search by Category.",
-    },
-    {
-      "<Leader>amfg",
-      function()
-        vim.ui.input({ prompt = "Tag: " }, function(tag)
-          require("front-matter-searcher").frontMatterPicker({
-            select_query = 'select(.tags[]? == "' .. tag .. '")',
-          })
-        end)
-      end,
-      desc = "⭐︎FrontMatterSearcher: Search by tag.",
-    },
-    {
-      "<Leader>amft",
-      function()
-        require("front-matter-searcher").frontMatterPicker()
-      end,
-      desc = "⭐︎FrontMatterSearcher: Search by title.",
-    },
-    -- dependencies: `iamcco/markdown-preview.nvim`
-    { "<Leader>amp", group = "Preview" },
-    { "<Leader>amps", "<cmd>MarkdownPreview<CR>", desc = "⭐︎MarkdownPreview: Start." },
-    { "<Leader>ampq", "<cmd>MarkdownPreviewStop<CR>", desc = "MarkdownPreview: Stop." },
-    { "<Leader>amt", group = "Timestamp" },
-    {
-      "<Leader>amtd",
-      function()
-        local ti = require("timestamp-inserter")
-        vim.api.nvim_put({ ti.timestamp2DateStr(ti.getNowEpoch()) }, "c", true, true)
-      end,
-      desc = "⭐︎TimestampInserter: Insert current date.",
-    },
-    {
-      "<Leader>amtf",
-      function()
-        local ti = require("timestamp-inserter")
-        vim.api.nvim_put({ ti.timestamp2DateTimeStr(ti.getNowEpoch()) }, "c", true, true)
-      end,
-      desc = "TimestampInserter: Insert current date and time.",
-    },
-    {
-      "<Leader>amtt",
-      function()
-        local ti = require("timestamp-inserter")
-        vim.api.nvim_put({ ti.timestamp2TimeStr(ti.getNowEpoch()) }, "c", true, true)
-      end,
-      desc = "⭐︎TimestampInserter: Insert current time.",
-    },
-    { "<Leader>amve", "<cmd>RenderMarkdown enable<CR>", desc = "⭐︎RenderMarkdown: Enable." },
-    { "<Leader>amvd", "<cmd>RenderMarkdown disable<CR>", desc = "⭐︎RenderMarkdown: Disable." },
-  })
+	require("which-key").add({
+		{ "<Leader>a", group = "Language" },
+		{ "<Leader>am", group = "Markdown" },
+		{
+			"<Leader>amb",
+			function()
+				require("markdown-hop-links").frontMatterPicker()
+			end,
+			desc = "⭐︎MarkdownLinkHops: Show backlinks.",
+		},
+		{ "<Leader>aml", group = "Auto lastmod" },
+		{ "<Leader>amlb", group = "Buffer" },
+		{
+			"<Leader>amlbd",
+			require("auto-lastmod").disable_buffer,
+			desc = "⭐︎AutoLastMod: Disable auto-lastmod",
+		},
+		{ "<Leader>amlbe", require("auto-lastmod").enable_buffer, desc = "AutoLastMod: Enable auto-lastmod" },
+		{ "<Leader>amlg", group = "Global" },
+		{
+			"<Leader>amlgd",
+			require("auto-lastmod").disable_global,
+			desc = "⭐︎AutoLastMod: Disable auto-lastmod",
+		},
+		{ "<Leader>amlge", require("auto-lastmod").enable_global, desc = "AutoLastMod: Enable auto-lastmod" },
+		{ "<Leader>amf", group = "Front matter" },
+		{
+			"<Leader>amfc",
+			function()
+				vim.ui.input({ prompt = "Category: " }, function(category)
+					require("front-matter-searcher").frontMatterPicker({
+						select_query = 'select(.categories[]? == "' .. category .. '")',
+					})
+				end)
+			end,
+			desc = "⭐︎FrontMatterSearcher: Search by Category.",
+		},
+		{
+			"<Leader>amfg",
+			function()
+				vim.ui.input({ prompt = "Tag: " }, function(tag)
+					require("front-matter-searcher").frontMatterPicker({
+						select_query = 'select(.tags[]? == "' .. tag .. '")',
+					})
+				end)
+			end,
+			desc = "⭐︎FrontMatterSearcher: Search by tag.",
+		},
+		{
+			"<Leader>amft",
+			function()
+				require("front-matter-searcher").frontMatterPicker()
+			end,
+			desc = "⭐︎FrontMatterSearcher: Search by title.",
+		},
+		-- dependencies: `iamcco/markdown-preview.nvim`
+		{ "<Leader>amp", group = "Preview" },
+		{ "<Leader>amps", "<cmd>MarkdownPreview<CR>", desc = "⭐︎MarkdownPreview: Start." },
+		{ "<Leader>ampq", "<cmd>MarkdownPreviewStop<CR>", desc = "MarkdownPreview: Stop." },
+		{ "<Leader>amt", group = "Timestamp" },
+		{
+			"<Leader>amtd",
+			function()
+				local ti = require("timestamp-inserter")
+				vim.api.nvim_put({ ti.timestamp2DateStr(ti.getNowEpoch()) }, "c", true, true)
+			end,
+			desc = "⭐︎TimestampInserter: Insert current date.",
+		},
+		{
+			"<Leader>amtf",
+			function()
+				local ti = require("timestamp-inserter")
+				vim.api.nvim_put({ ti.timestamp2DateTimeStr(ti.getNowEpoch()) }, "c", true, true)
+			end,
+			desc = "TimestampInserter: Insert current date and time.",
+		},
+		{
+			"<Leader>amtt",
+			function()
+				local ti = require("timestamp-inserter")
+				vim.api.nvim_put({ ti.timestamp2TimeStr(ti.getNowEpoch()) }, "c", true, true)
+			end,
+			desc = "⭐︎TimestampInserter: Insert current time.",
+		},
+		{ "<Leader>amve", "<cmd>RenderMarkdown enable<CR>", desc = "⭐︎RenderMarkdown: Enable." },
+		{ "<Leader>amvd", "<cmd>RenderMarkdown disable<CR>", desc = "⭐︎RenderMarkdown: Disable." },
+	})
 end
 
 -- LSPとLLMに関連するキー登録
 --
 -- dependencies: `CopilotC-Nvim/CopilotChat.nvim`
 local function registerLspAndLlmKey()
-  -- Normal mode
-  require("which-key").add({
-    { "<Leader>l",    group = "LSP and LLM" },
-    { "<Leader>la",   group = "Avante" },
-    { "<Leader>laa",  "<cmd>AvanteAsk<CR>",                           desc = "Avante: Ask mode.",                                 mode = { "n", "v" } },
-    { "<Leader>lae",  "<cmd>AvanteEdit<CR>",                          desc = "Avante: Edit mode.",                                mode = { "n", "v" } },
-    { "<Leader>laf",  "<cmd>AvanteFocus<CR>",                         desc = "Avante: Switch focus to/from the sidebar.",         mode = { "n" } },
-    { "<Leader>lag",  "<cmd>AvanteToggle<CR>",                        desc = "Avante: Toggle the sidebar.",                       mode = { "n", "v" } },
-    { "<Leader>lah",  "<cmd>AvanteHistory<CR>",                       desc = "Avante: Show history.",                             mode = { "n" } },
-    { "<Leader>lam",  "<cmd>AvanteModels<CR>",                        desc = "Avante: Select model.",                             mode = { "n" } },
-    { "<Leader>las",  group = "Avante providers" },
-    { "<Leader>lasg", "<cmd>AvanteSwitchProvider copilot_gpt<CR>",    desc = "Avante: Switch provider to GitHub Copilot GPT.",    mode = { "n" } },
-    { "<Leader>lasg", "<cmd>AvanteSwitchProvider copilot_claude<CR>", desc = "Avante: Switch provider to GitHub Copilot Calude.", mode = { "n" } },
-    { "<Leader>lat",  "<cmd>AvanteStop<CR>",                          desc = "Avante: Stop the current AI request.",              mode = { "n" } },
-    { "<Leader>lc",   group = "GitHub Copilot Chat" },
-    {
-      "<Leader>lcc",
-      function()
-        require("CopilotChat").close()
-      end,
-      desc = "CopilotChat: Close chat window.",
-    },
-    {
-      "<Leader>lci",
-      function()
-        require("CopilotChat").toggle({
-          window = {
-            layout = "float",
-            title = "CopilotChat - Inline Chat",
-            relative = "cursor",
-            width = 1,
-            height = 0.4,
-            row = 1,
-          },
-        })
-      end,
-      desc = "⭐︎CopilotChat: Inline chat",
-    },
-    { "<Leader>lco", "<cmd>CopilotChatOpen<CR>", desc = "⭐︎CopilotChat: Open chat window." },
-    {
-      "<Leader>lcq",
-      function()
-        vim.ui.input({ prompt = "Quick Chat: " }, function(text)
-          if text ~= "" then
-            require("CopilotChat").ask(text, { selection = require("CopilotChat.select").buffer })
-          end
-        end)
-      end,
-      desc = "⭐︎CopilotChat: Quick chat",
-    },
-    {
-      "<Leader>lcq",
-      function()
-        local input = vim.fn.input("Quick Chat: ")
-        if input ~= "" then
-          require("CopilotChat").ask(input, { selection = require("CopilotChat.select").visual })
-        end
-      end,
-      desc = "⭐︎CopilotChat: Quick chat",
-      mode = { "v" },
-    },
-    {
-      "<Leader>lcr",
-      function()
-        require("CopilotChat").reset()
-      end,
-      desc = "CopilotChat: Reset chat window.",
-    },
-    -- `<Leader>le`はLSPのtelescope利用版で利用済み
-    { "<Leader>lg", group = "GitHub Copilot" },
-    { "<Leader>lge", "<cmd>Copilot enable<CR>", desc = "Copilot: Enable." },
-    { "<Leader>lgd", "<cmd>Copilot disable<CR>", desc = "Copilot: Disable." },
-    { "<Leader>lgi", "<cmd>Copilot signin<CR>", desc = "Copilot: Signin." },
-    { "<Leader>lgo", "<cmd>Copilot signout<CR>", desc = "Copilot: Signout." },
-    { "<Leader>lgp", "<cmd>Copilot panel<CR>", desc = "Copilot: Show panel." },
-    { "<Leader>lgr", "<cmd>Copilot restart<CR>", desc = "Copilot: Restart." },
-    { "<Leader>lgs", "<cmd>Copilot status<CR>", desc = "⭐︎Copilot: Show status." },
-    { "<Leader>lgu", "<cmd>Copilot setup<CR>", desc = "Copilot: Setup." },
-    -- `<Leader>ll`はLSPで利用済み
-    { "<Leader>lm", group = "CodeCompanion" },
-    {
-      "<Leader>lma",
-      "<cmd>CodeCompanionAction<CR>",
-      desc = "CodeCompanion: Open action.",
-      mode = { "n", "v" },
-    },
-    {
-      "<Leader>lmc",
-      "<cmd>CodeCompanionChat<CR>",
-      desc = "CodeCompanion: Open chat.",
-      mode = { "n", "v" },
-    },
-    {
-      "<Leader>lmi",
-      "<cmd>CodeCompanion<CR>",
-      desc = "CodeCompanion: Open inline chat.",
-      mode = { "n", "v" },
-    },
-    { "<Leader>lp", "<cmd>MCPHub<CR>", desc = "MCPHub: Open.", mode = { "n" } },
-    { "<Leader>lt", group = "Trouble" },
-    {
-      "<Leader>ltd",
-      function()
-        require("trouble").toggle("document_diagnostics")
-      end,
-      desc = "Trouble: Toggle document diagnostics.",
-    },
-    {
-      "<Leader>ltl",
-      function()
-        require("trouble").toggle("loclist")
-      end,
-      desc = "Trouble: Toggle location list.",
-    },
-    {
-      "<Leader>ltq",
-      function()
-        require("trouble").toggle("quickfix")
-      end,
-      desc = "Trouble: Toggle quickfix.",
-    },
-    {
-      "<Leader>ltr",
-      function()
-        require("trouble").toggle("lsp_references")
-      end,
-      desc = "Trouble: Toggle LSP references.",
-    },
-    {
-      "<Leader>ltw",
-      function()
-        require("trouble").toggle("workspace_diagnostics")
-      end,
-      desc = "Trouble: Toggle workspace diagnostics.",
-    },
-    {
-      "<Leader>ltx",
-      function()
-        require("trouble").toggle()
-      end,
-      desc = "Trouble: Toggle.",
-    },
-    { "<Leader>lu",  group = "Claude" },
-    { "<Leader>luc", "<cmd>ClaudeCodeContinue<CR>", desc = "ClaudeCode: Resume the most recent conversation.",        mode = { "n" } },
-    { "<Leader>luo", "<cmd>ClaudeCode<CR>",         desc = "ClaudeCode: Open.",                                       mode = { "n" } },
-    { "<Leader>lur", "<cmd>ClaudeCodeContinue<CR>", desc = "ClaudeCode: Resume the most recent conversation.",        mode = { "n" } },
-    { "<Leader>lur", "<cmd>ClaudeCodeResume<CR>",   desc = "ClaudeCode: Display an interactive conversation picker.", mode = { "n" } },
-  })
+	-- Normal mode
+	require("which-key").add({
+		{ "<Leader>l", group = "LSP and LLM" },
+		{ "<Leader>la", group = "Avante" },
+		{
+			"<Leader>laa",
+			"<cmd>AvanteAsk<CR>",
+			desc = "Avante: Ask mode.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>lae",
+			"<cmd>AvanteEdit<CR>",
+			desc = "Avante: Edit mode.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>laf",
+			"<cmd>AvanteFocus<CR>",
+			desc = "Avante: Switch focus to/from the sidebar.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lag",
+			"<cmd>AvanteToggle<CR>",
+			desc = "Avante: Toggle the sidebar.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>lah",
+			"<cmd>AvanteHistory<CR>",
+			desc = "Avante: Show history.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lam",
+			"<cmd>AvanteModels<CR>",
+			desc = "Avante: Select model.",
+			mode = { "n" },
+		},
+		{ "<Leader>las", group = "Avante providers" },
+		{
+			"<Leader>lasg",
+			"<cmd>AvanteSwitchProvider copilot_gpt<CR>",
+			desc = "Avante: Switch provider to GitHub Copilot GPT.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lasg",
+			"<cmd>AvanteSwitchProvider copilot_claude<CR>",
+			desc = "Avante: Switch provider to GitHub Copilot Calude.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lat",
+			"<cmd>AvanteStop<CR>",
+			desc = "Avante: Stop the current AI request.",
+			mode = { "n" },
+		},
+		{ "<Leader>lc", group = "GitHub Copilot Chat" },
+		{
+			"<Leader>lcc",
+			function()
+				require("CopilotChat").close()
+			end,
+			desc = "CopilotChat: Close chat window.",
+		},
+		{
+			"<Leader>lci",
+			function()
+				require("CopilotChat").toggle({
+					window = {
+						layout = "float",
+						title = "CopilotChat - Inline Chat",
+						relative = "cursor",
+						width = 1,
+						height = 0.4,
+						row = 1,
+					},
+				})
+			end,
+			desc = "⭐︎CopilotChat: Inline chat",
+		},
+		{ "<Leader>lco", "<cmd>CopilotChatOpen<CR>", desc = "⭐︎CopilotChat: Open chat window." },
+		{
+			"<Leader>lcq",
+			function()
+				vim.ui.input({ prompt = "Quick Chat: " }, function(text)
+					if text ~= "" then
+						require("CopilotChat").ask(text, { selection = require("CopilotChat.select").buffer })
+					end
+				end)
+			end,
+			desc = "⭐︎CopilotChat: Quick chat",
+		},
+		{
+			"<Leader>lcq",
+			function()
+				local input = vim.fn.input("Quick Chat: ")
+				if input ~= "" then
+					require("CopilotChat").ask(input, { selection = require("CopilotChat.select").visual })
+				end
+			end,
+			desc = "⭐︎CopilotChat: Quick chat",
+			mode = { "v" },
+		},
+		{
+			"<Leader>lcr",
+			function()
+				require("CopilotChat").reset()
+			end,
+			desc = "CopilotChat: Reset chat window.",
+		},
+		-- `<Leader>le`はLSPのtelescope利用版で利用済み
+		{ "<Leader>lg", group = "GitHub Copilot" },
+		{ "<Leader>lge", "<cmd>Copilot enable<CR>", desc = "Copilot: Enable." },
+		{ "<Leader>lgd", "<cmd>Copilot disable<CR>", desc = "Copilot: Disable." },
+		{ "<Leader>lgi", "<cmd>Copilot signin<CR>", desc = "Copilot: Signin." },
+		{ "<Leader>lgo", "<cmd>Copilot signout<CR>", desc = "Copilot: Signout." },
+		{ "<Leader>lgp", "<cmd>Copilot panel<CR>", desc = "Copilot: Show panel." },
+		{ "<Leader>lgr", "<cmd>Copilot restart<CR>", desc = "Copilot: Restart." },
+		{ "<Leader>lgs", "<cmd>Copilot status<CR>", desc = "⭐︎Copilot: Show status." },
+		{ "<Leader>lgu", "<cmd>Copilot setup<CR>", desc = "Copilot: Setup." },
+		-- `<Leader>ll`はLSPで利用済み
+		{ "<Leader>lm", group = "CodeCompanion" },
+		{
+			"<Leader>lma",
+			"<cmd>CodeCompanionAction<CR>",
+			desc = "CodeCompanion: Open action.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>lmc",
+			"<cmd>CodeCompanionChat<CR>",
+			desc = "CodeCompanion: Open chat.",
+			mode = { "n", "v" },
+		},
+		{
+			"<Leader>lmi",
+			"<cmd>CodeCompanion<CR>",
+			desc = "CodeCompanion: Open inline chat.",
+			mode = { "n", "v" },
+		},
+		{ "<Leader>lp", "<cmd>MCPHub<CR>", desc = "MCPHub: Open.", mode = { "n" } },
+		{ "<Leader>lt", group = "Trouble" },
+		{
+			"<Leader>ltd",
+			function()
+				require("trouble").toggle("document_diagnostics")
+			end,
+			desc = "Trouble: Toggle document diagnostics.",
+		},
+		{
+			"<Leader>ltl",
+			function()
+				require("trouble").toggle("loclist")
+			end,
+			desc = "Trouble: Toggle location list.",
+		},
+		{
+			"<Leader>ltq",
+			function()
+				require("trouble").toggle("quickfix")
+			end,
+			desc = "Trouble: Toggle quickfix.",
+		},
+		{
+			"<Leader>ltr",
+			function()
+				require("trouble").toggle("lsp_references")
+			end,
+			desc = "Trouble: Toggle LSP references.",
+		},
+		{
+			"<Leader>ltw",
+			function()
+				require("trouble").toggle("workspace_diagnostics")
+			end,
+			desc = "Trouble: Toggle workspace diagnostics.",
+		},
+		{
+			"<Leader>ltx",
+			function()
+				require("trouble").toggle()
+			end,
+			desc = "Trouble: Toggle.",
+		},
+		{ "<Leader>lu", group = "Claude" },
+		{
+			"<Leader>luc",
+			"<cmd>ClaudeCodeContinue<CR>",
+			desc = "ClaudeCode: Resume the most recent conversation.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>luo",
+			"<cmd>ClaudeCode<CR>",
+			desc = "ClaudeCode: Open.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lur",
+			"<cmd>ClaudeCodeContinue<CR>",
+			desc = "ClaudeCode: Resume the most recent conversation.",
+			mode = { "n" },
+		},
+		{
+			"<Leader>lur",
+			"<cmd>ClaudeCodeResume<CR>",
+			desc = "ClaudeCode: Display an interactive conversation picker.",
+			mode = { "n" },
+		},
+	})
 
-  -- LspAttachしたときのみ設定を追加
-  vim.api.nvim_create_autocmd("LspAttach", {
-    callback = function(ctx)
-      -- see: <https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#suggested-configuration>
-      require("which-key").add({
-        { "<Leader>le",  group = "LSP with telescope" },
-        {
-          "<Leader>led",
-          require("telescope.builtin").lsp_definitions,
-          desc = "LSP Telescope: Go to definition.",
-        },
-        { "<Leader>lee", group = "Diagnostics" },
-        {
-          "<Leader>leeb",
-          function()
-            require("telescope.builtin").diagnostics({ bufnr = 0 })
-          end,
-          desc = "LSP Telescope: Lists diagnostics for all open buffers.",
-        },
-        {
-          "<Leader>leew",
-          require("telescope.builtin").diagnostics,
-          desc = "LSP Telescope: Lists diagnostics for all open buffers.",
-        },
-        {
-          "<Leader>lei",
-          require("telescope.builtin").lsp_implementations,
-          desc = "LSP Telescope: Go to implementation.",
-        },
-        {
-          "<Leader>len",
-          require("telescope.builtin").lsp_incoming_calls,
-          desc = "LSP Telescope: Lists LSP incoming calls.",
-        },
-        {
-          "<Leader>leo",
-          require("telescope.builtin").lsp_outgoing_calls,
-          desc = "LSP Telescope: Lists LSP outgoing calls.",
-        },
-        {
-          "<Leader>ler",
-          require("telescope.builtin").lsp_references,
-          desc = "LSP Telescope: Lists LSP References.",
-        },
-        { "<Leader>les", group = "Document symbols" },
-        {
-          "<Leader>lesb",
-          require("telescope.builtin").lsp_document_symbols,
-          desc = "LSP Telescope: Lists LSP document symbols in the current buffer.",
-        },
-        {
-          "<Leader>lesw",
-          require("telescope.builtin").lsp_workspace_symbols,
-          desc = "LSP Telescope: Lists LSP document symbols in the current workspace.",
-        },
-        {
-          "<Leader>lesy",
-          require("telescope.builtin").lsp_dynamic_workspace_symbols,
-          desc = "LSP Telescope: Dynamically lists LSP for all workspace symbols.",
-        },
-        {
-          "<Leader>let",
-          require("telescope.builtin").lsp_type_definitions,
-          desc = "LSP Telescope: Go to definition of the type.",
-        },
-        { "<Leader>ll", group = "LSP" },
-        { "<Leader>lla", vim.lsp.buf.code_action, desc = "⭐︎LSP: Code action." },
-        { "<Leader>lld", vim.lsp.buf.definition, desc = "⭐︎LSP: Go to definition." },
-        { "<Leader>llD", vim.lsp.buf.declaration, desc = "⭐︎LSP: Go to declaration." },
-        { "<Leader>lle", group = "Diagnostic" },
-        { "<Leader>lleo", vim.diagnostic.open_float, desc = "⭐︎LSP: Show line diagnostics." },
-        { "<Leader>llep", vim.diagnostic.goto_prev, desc = "⭐︎LSP: Go to previous diagnostics." },
-        { "<Leader>llen", vim.diagnostic.goto_next, desc = "⭐︎LSP: Go to next diagnostics." },
-        { "<Leader>llel", vim.diagnostic.setloclist, desc = "⭐︎LSP: Set loclist diagnostics." },
-        {
-          "<Leader>llf",
-          function()
-            vim.lsp.buf.format({ async = true })
-          end,
-          desc = "⭐︎LSP: Formatting.",
-        },
-        { "<Leader>lli", vim.lsp.buf.implementation, desc = "⭐︎LSP: Go to implementation." },
-        { "<Leader>llk", vim.lsp.buf.signature_help, desc = "⭐︎LSP: Show signature help." },
-        { "<Leader>llK", vim.lsp.buf.hover, desc = "⭐︎LSP: Show hover." },
-        { "<Leader>lln", vim.lsp.buf.rename, desc = "⭐︎LSP: Rename." },
-        { "<Leader>llr", vim.lsp.buf.references, desc = "⭐︎LSP: Show references." },
-        { "<Leader>lls", "<cmd>LspInfo<CR>", desc = "⭐︎LSP: Show lsp info." },
-        { "<Leader>llt", vim.lsp.buf.type_definition, desc = "⭐︎LSP: Type definition." },
-        { "<Leader>llw", group = "workspace" },
-        { "<Leader>llwa", vim.lsp.buf.add_workspace_folder, desc = "LSP: Add workspace folder." },
-        { "<Leader>llwr", vim.lsp.buf.remove_workspace_folder, desc = "LSP: Remove workspace folder." },
-        { "<Leader>llwl", vim.lsp.buf.list_workspace_folders, desc = "LSP: List workspace folders." },
-      }, {
-        buffer = ctx.buff,
-      })
-    end,
-  })
+	-- LspAttachしたときのみ設定を追加
+	vim.api.nvim_create_autocmd("LspAttach", {
+		callback = function(ctx)
+			-- see: <https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#suggested-configuration>
+			require("which-key").add({
+				{ "<Leader>le", group = "LSP with telescope" },
+				{
+					"<Leader>led",
+					require("telescope.builtin").lsp_definitions,
+					desc = "LSP Telescope: Go to definition.",
+				},
+				{ "<Leader>lee", group = "Diagnostics" },
+				{
+					"<Leader>leeb",
+					function()
+						require("telescope.builtin").diagnostics({ bufnr = 0 })
+					end,
+					desc = "LSP Telescope: Lists diagnostics for all open buffers.",
+				},
+				{
+					"<Leader>leew",
+					require("telescope.builtin").diagnostics,
+					desc = "LSP Telescope: Lists diagnostics for all open buffers.",
+				},
+				{
+					"<Leader>lei",
+					require("telescope.builtin").lsp_implementations,
+					desc = "LSP Telescope: Go to implementation.",
+				},
+				{
+					"<Leader>len",
+					require("telescope.builtin").lsp_incoming_calls,
+					desc = "LSP Telescope: Lists LSP incoming calls.",
+				},
+				{
+					"<Leader>leo",
+					require("telescope.builtin").lsp_outgoing_calls,
+					desc = "LSP Telescope: Lists LSP outgoing calls.",
+				},
+				{
+					"<Leader>ler",
+					require("telescope.builtin").lsp_references,
+					desc = "LSP Telescope: Lists LSP References.",
+				},
+				{ "<Leader>les", group = "Document symbols" },
+				{
+					"<Leader>lesb",
+					require("telescope.builtin").lsp_document_symbols,
+					desc = "LSP Telescope: Lists LSP document symbols in the current buffer.",
+				},
+				{
+					"<Leader>lesw",
+					require("telescope.builtin").lsp_workspace_symbols,
+					desc = "LSP Telescope: Lists LSP document symbols in the current workspace.",
+				},
+				{
+					"<Leader>lesy",
+					require("telescope.builtin").lsp_dynamic_workspace_symbols,
+					desc = "LSP Telescope: Dynamically lists LSP for all workspace symbols.",
+				},
+				{
+					"<Leader>let",
+					require("telescope.builtin").lsp_type_definitions,
+					desc = "LSP Telescope: Go to definition of the type.",
+				},
+				{ "<Leader>ll", group = "LSP" },
+				{ "<Leader>lla", vim.lsp.buf.code_action, desc = "⭐︎LSP: Code action." },
+				{ "<Leader>lld", vim.lsp.buf.definition, desc = "⭐︎LSP: Go to definition." },
+				{ "<Leader>llD", vim.lsp.buf.declaration, desc = "⭐︎LSP: Go to declaration." },
+				{ "<Leader>lle", group = "Diagnostic" },
+				{ "<Leader>lleo", vim.diagnostic.open_float, desc = "⭐︎LSP: Show line diagnostics." },
+				{ "<Leader>llep", vim.diagnostic.goto_prev, desc = "⭐︎LSP: Go to previous diagnostics." },
+				{ "<Leader>llen", vim.diagnostic.goto_next, desc = "⭐︎LSP: Go to next diagnostics." },
+				{ "<Leader>llel", vim.diagnostic.setloclist, desc = "⭐︎LSP: Set loclist diagnostics." },
+				{
+					"<Leader>llf",
+					function()
+						vim.lsp.buf.format({ async = true })
+					end,
+					desc = "⭐︎LSP: Formatting.",
+				},
+				{ "<Leader>lli", vim.lsp.buf.implementation, desc = "⭐︎LSP: Go to implementation." },
+				{ "<Leader>llk", vim.lsp.buf.signature_help, desc = "⭐︎LSP: Show signature help." },
+				{ "<Leader>llK", vim.lsp.buf.hover, desc = "⭐︎LSP: Show hover." },
+				{ "<Leader>lln", vim.lsp.buf.rename, desc = "⭐︎LSP: Rename." },
+				{ "<Leader>llr", vim.lsp.buf.references, desc = "⭐︎LSP: Show references." },
+				{ "<Leader>lls", "<cmd>LspInfo<CR>", desc = "⭐︎LSP: Show lsp info." },
+				{ "<Leader>llt", vim.lsp.buf.type_definition, desc = "⭐︎LSP: Type definition." },
+				{ "<Leader>llw", group = "workspace" },
+				{ "<Leader>llwa", vim.lsp.buf.add_workspace_folder, desc = "LSP: Add workspace folder." },
+				{ "<Leader>llwr", vim.lsp.buf.remove_workspace_folder, desc = "LSP: Remove workspace folder." },
+				{ "<Leader>llwl", vim.lsp.buf.list_workspace_folders, desc = "LSP: List workspace folders." },
+			}, {
+				buffer = ctx.buff,
+			})
+		end,
+	})
 end
 
 -- Marks関連のキー登録
 local function registerMarkKey()
-  require("which-key").add({
-    { "<Leader>m", group = "Marks" },
-    { "<Leader>ml", require("telescope.builtin").marks, desc = "⭐︎Telescope: Lists vim marks." },
-  })
+	require("which-key").add({
+		{ "<Leader>m", group = "Marks" },
+		{ "<Leader>ml", require("telescope.builtin").marks, desc = "⭐︎Telescope: Lists vim marks." },
+	})
 end
 
 -- Outline関連のキー登録
@@ -800,32 +879,32 @@ end
 --   - `hedyhli/outline.nvim`
 --   - `stevearc/aerial.nvim`
 local function registerOutlineKey()
-  require("which-key").add({
-    { "<Leader>o", group = "Outline" },
-    { "<Leader>of", "<cmd>OutlineFollow<CR>", desc = "Outline: Go follow cursor position." },
-    { "<Leader>oo", "<cmd>OutlineOpen<CR>", desc = "⭐︎Outline: Open." },
-    { "<Leader>oq", "<cmd>OutlineClose<CR>", desc = "Outline: Close." },
-    { "<Leader>os", "<cmd>OutlineStatus<CR>", desc = "Outline: Show status." },
-    { "<Leader>or", "<cmd>OutlinesRefresh<CR>", desc = "Outline: Refresh of symbols." },
-    { "<Leader>ot", "<cmd>Telescope aerial<CR>", desc = "Aerial: Open using telescope." },
-  })
+	require("which-key").add({
+		{ "<Leader>o", group = "Outline" },
+		{ "<Leader>of", "<cmd>OutlineFollow<CR>", desc = "Outline: Go follow cursor position." },
+		{ "<Leader>oo", "<cmd>OutlineOpen<CR>", desc = "⭐︎Outline: Open." },
+		{ "<Leader>oq", "<cmd>OutlineClose<CR>", desc = "Outline: Close." },
+		{ "<Leader>os", "<cmd>OutlineStatus<CR>", desc = "Outline: Show status." },
+		{ "<Leader>or", "<cmd>OutlinesRefresh<CR>", desc = "Outline: Refresh of symbols." },
+		{ "<Leader>ot", "<cmd>Telescope aerial<CR>", desc = "Aerial: Open using telescope." },
+	})
 end
 
 -- QuickfixとLocation関連のキー登録
 local function registerQuickfixAndLocation()
-  require("which-key").add({
-    { "<Leader>q", group = "Quickfix and Location list" },
-    { "<Leader>ql", group = "Location list" },
-    { "<Leader>qln", "<cmd>lnext<CR>", desc = "⭐︎Location: Next." },
-    { "<Leader>qlo", "<cmd>lopen<CR>", desc = "⭐︎Location: Open." },
-    { "<Leader>qlp", "<cmd>lprevious<CR>", desc = "⭐︎Location: Previous." },
-    { "<Leader>qlq", "<cmd>lclose<CR>", desc = "⭐︎Location: Close." },
-    { "<Leader>qq", group = "Quickfix" },
-    { "<Leader>qqn", "<cmd>cnext<CR>", desc = "⭐︎Quickfix: Next." },
-    { "<Leader>qqo", "<cmd>copen<CR>", desc = "⭐︎Quickfix: Open." },
-    { "<Leader>qqp", "<cmd>cprevious<CR>", desc = "⭐︎Quickfix: Previous." },
-    { "<Leader>qqq", "<cmd>cclose<CR>", desc = "⭐︎Quickfix: Close." },
-  })
+	require("which-key").add({
+		{ "<Leader>q", group = "Quickfix and Location list" },
+		{ "<Leader>ql", group = "Location list" },
+		{ "<Leader>qln", "<cmd>lnext<CR>", desc = "⭐︎Location: Next." },
+		{ "<Leader>qlo", "<cmd>lopen<CR>", desc = "⭐︎Location: Open." },
+		{ "<Leader>qlp", "<cmd>lprevious<CR>", desc = "⭐︎Location: Previous." },
+		{ "<Leader>qlq", "<cmd>lclose<CR>", desc = "⭐︎Location: Close." },
+		{ "<Leader>qq", group = "Quickfix" },
+		{ "<Leader>qqn", "<cmd>cnext<CR>", desc = "⭐︎Quickfix: Next." },
+		{ "<Leader>qqo", "<cmd>copen<CR>", desc = "⭐︎Quickfix: Open." },
+		{ "<Leader>qqp", "<cmd>cprevious<CR>", desc = "⭐︎Quickfix: Previous." },
+		{ "<Leader>qqq", "<cmd>cclose<CR>", desc = "⭐︎Quickfix: Close." },
+	})
 end
 
 -- Terminal関連のキー登録
@@ -834,140 +913,148 @@ end
 -- `exe v:count1 . "ToggleTerm"`では、コマンドの前に数字を設定することで任意の端末を開くことができる。
 -- 数字を設定しなければ、最初の端末を開くことができきる。
 local function registerTerminalAndToolsKey()
-  require("which-key").add({
-    { "<Leader>t", group = "Terminal and Tools" },
-    { "<Leader>tl", "<cmd>Lazy<CR>", desc = "⭐︎Lazy: Show Lazy UI." },
-    { "<Leader>tm", group = "Mason" },
-    { "<Leader>tml", "<cmd>MasonLog<CR>", desc = "Mason: Show log." },
-    { "<Leader>tmo", "<cmd>Mason<CR>", desc = "⭐︎Mason: Show Mason UI." },
-    { "<Leader>tmu", group = "Update" },
-    { "<Leader>tmum", "<cmd>MasonUpdate<CR>", desc = "Mason: update." },
-    { "<Leader>tmut", "<cmd>MasonToolsUpdate<CR>", desc = "MasonTools: update." },
-    { "<Leader>tt", group = "Terminal" },
-    {
-      "<Leader>ttf",
-      "<cmd>exe v:count1 . \"ToggleTerm direction='float'\"<CR>",
-      desc = "⭐︎ToggleTerm: Open floating terminal.",
-    },
-    {
-      "<Leader>tth",
-      "<cmd>exe v:count1 . \"ToggleTerm direction='horizontal'\"<CR>",
-      desc = "⭐︎ToggleTerm: Open horizontal terminal.",
-    },
-    { "<Leader>ttn",  "<cmd>ToggleTermSetName<CR>",             desc = "ToggleTerm: Set a display name." },
-    { "<Leader>ttp",  "<cmd>TermSelect<CR>",                    desc = "ToggleTerm: Select a terminal." },
-    { "<Leader>tts",  group = "Send to terminal" },
-    { "<Leader>ttsl", "<cmd>ToggleTermSendCurrentLine<CR>",     desc = "ToggleTerm: Send current line to terminal." },
-    { "<Leader>ttsv", "<cmd>ToggleTermSendVisualLines<CR>",     desc = "ToggleTerm: Send selected lines to terminal." },
-    { "<Leader>ttss", "<cmd>ToggleTermSendVisualSelection<CR>", desc = "ToggleTerm: Send selection to terminal." },
-    {
-      "<Leader>ttt",
-      "<cmd>exe v:count1 . \"ToggleTerm direction='tab'\"<CR>",
-      desc = "ToggleTerm: Open tab terminal.",
-    },
-    {
-      "<Leader>ttv",
-      "<cmd>exe v:count1 . \"ToggleTerm direction='vertical'\"<CR>",
-      desc = "ToggleTerm: Open vertical terminal.",
-    },
-    { "<Leader>ts",   group = "Tree sitter" },
-    { "<Leader>tsc",  group = "Context" },
-    { "<Leader>tsce", "<cmd>TSContextEnable<CR>",  desc = "TreeSitter: Enable Context." },
-    { "<Leader>tscd", "<cmd>TSContextDisable<CR>", desc = "TreeSitter: Disable Context." },
-    {
-      "<Leader>tscj",
-      function()
-        require("treesitter-context").go_to_context(vim.v.count1)
-      end,
-      desc = "TreeSitter: Jumping to context(upwards).",
-    },
-    { "<Leader>tsu", "<cmd>TSUpdate<CR>", desc = "TreeSitter: Update Tree-Sitter" },
-  })
+	require("which-key").add({
+		{ "<Leader>t", group = "Terminal and Tools" },
+		{ "<Leader>tl", "<cmd>Lazy<CR>", desc = "⭐︎Lazy: Show Lazy UI." },
+		{ "<Leader>tm", group = "Mason" },
+		{ "<Leader>tml", "<cmd>MasonLog<CR>", desc = "Mason: Show log." },
+		{ "<Leader>tmo", "<cmd>Mason<CR>", desc = "⭐︎Mason: Show Mason UI." },
+		{ "<Leader>tmu", group = "Update" },
+		{ "<Leader>tmum", "<cmd>MasonUpdate<CR>", desc = "Mason: update." },
+		{ "<Leader>tmut", "<cmd>MasonToolsUpdate<CR>", desc = "MasonTools: update." },
+		{ "<Leader>tt", group = "Terminal" },
+		{
+			"<Leader>ttf",
+			"<cmd>exe v:count1 . \"ToggleTerm direction='float'\"<CR>",
+			desc = "⭐︎ToggleTerm: Open floating terminal.",
+		},
+		{
+			"<Leader>tth",
+			"<cmd>exe v:count1 . \"ToggleTerm direction='horizontal'\"<CR>",
+			desc = "⭐︎ToggleTerm: Open horizontal terminal.",
+		},
+		{ "<Leader>ttn", "<cmd>ToggleTermSetName<CR>", desc = "ToggleTerm: Set a display name." },
+		{ "<Leader>ttp", "<cmd>TermSelect<CR>", desc = "ToggleTerm: Select a terminal." },
+		{ "<Leader>tts", group = "Send to terminal" },
+		{
+			"<Leader>ttsl",
+			"<cmd>ToggleTermSendCurrentLine<CR>",
+			desc = "ToggleTerm: Send current line to terminal.",
+		},
+		{
+			"<Leader>ttsv",
+			"<cmd>ToggleTermSendVisualLines<CR>",
+			desc = "ToggleTerm: Send selected lines to terminal.",
+		},
+		{ "<Leader>ttss", "<cmd>ToggleTermSendVisualSelection<CR>", desc = "ToggleTerm: Send selection to terminal." },
+		{
+			"<Leader>ttt",
+			"<cmd>exe v:count1 . \"ToggleTerm direction='tab'\"<CR>",
+			desc = "ToggleTerm: Open tab terminal.",
+		},
+		{
+			"<Leader>ttv",
+			"<cmd>exe v:count1 . \"ToggleTerm direction='vertical'\"<CR>",
+			desc = "ToggleTerm: Open vertical terminal.",
+		},
+		{ "<Leader>ts", group = "Tree sitter" },
+		{ "<Leader>tsc", group = "Context" },
+		{ "<Leader>tsce", "<cmd>TSContextEnable<CR>", desc = "TreeSitter: Enable Context." },
+		{ "<Leader>tscd", "<cmd>TSContextDisable<CR>", desc = "TreeSitter: Disable Context." },
+		{
+			"<Leader>tscj",
+			function()
+				require("treesitter-context").go_to_context(vim.v.count1)
+			end,
+			desc = "TreeSitter: Jumping to context(upwards).",
+		},
+		{ "<Leader>tsu", "<cmd>TSUpdate<CR>", desc = "TreeSitter: Update Tree-Sitter" },
+	})
 end
 
 -- Workspace関連のキー登録
 local function registerWorkspaceKey()
-  -- Normal mode
-  require("which-key").add({
-    { "<Leader>w", group = "Workspace" },
-    {
-      "<Leader>wn",
-      -- dependencies: `rcarriga/nvim-notify`
-      "<cmd>Telescope notify<CR>",
-      desc = "⭐︎Telescope: Show notify.",
-    },
-    { "<Leader>wt", group = "Tab" },
-    { "<Leader>wtn", "<cmd>tabnext<CR>", desc = "⭐︎Tab: Move next tab." },
-    { "<Leader>wto", "<cmd>tabnew<CR>", desc = "⭐︎Tab: Open a new tab." },
-    { "<Leader>wtp", "<cmd>tabprevious<CR>", desc = "⭐︎Tab: Move previous tab." },
-    { "<Leader>wtq", "<cmd>tabclose<CR>", desc = "⭐︎Tab: Close tab." },
-    { "<Leader>wv", group = "VSCode" },
-    {
-      "<Leader>wvb",
-      -- 現在のバッファをvscodeで開く
-      function()
-        if vim.fn.executable("code") == 0 then
-          vim.notify("code command not found.")
-          return
-        end
+	-- Normal mode
+	require("which-key").add({
+		{ "<Leader>w", group = "Workspace" },
+		{
+			"<Leader>wn",
+			-- dependencies: `rcarriga/nvim-notify`
+			"<cmd>Telescope notify<CR>",
+			desc = "⭐︎Telescope: Show notify.",
+		},
+		{ "<Leader>wt", group = "Tab" },
+		{ "<Leader>wtn", "<cmd>tabnext<CR>", desc = "⭐︎Tab: Move next tab." },
+		{ "<Leader>wto", "<cmd>tabnew<CR>", desc = "⭐︎Tab: Open a new tab." },
+		{ "<Leader>wtp", "<cmd>tabprevious<CR>", desc = "⭐︎Tab: Move previous tab." },
+		{ "<Leader>wtq", "<cmd>tabclose<CR>", desc = "⭐︎Tab: Close tab." },
+		{ "<Leader>wv", group = "VSCode" },
+		{
+			"<Leader>wvb",
+			-- 現在のバッファをvscodeで開く
+			function()
+				if vim.fn.executable("code") == 0 then
+					vim.notify("code command not found.")
+					return
+				end
 
-        local project_path = vim.fn.getcwd()
-        local file_path = vim.fn.expand("%:p")
-        vim.fn.jobstart({ "code", project_path, file_path }, { detach = true })
-      end,
-      desc = "⭐︎VSCode: Open file.",
-    },
-    {
-      "<Leader>wvw",
-      -- 同じフォルダでvsocdeを開く
-      function()
-        if vim.fn.executable("code") == 0 then
-          vim.notify("code command not found.")
-          return
-        end
+				local project_path = vim.fn.getcwd()
+				local file_path = vim.fn.expand("%:p")
+				vim.fn.jobstart({ "code", project_path, file_path }, { detach = true })
+			end,
+			desc = "⭐︎VSCode: Open file.",
+		},
+		{
+			"<Leader>wvw",
+			-- 同じフォルダでvsocdeを開く
+			function()
+				if vim.fn.executable("code") == 0 then
+					vim.notify("code command not found.")
+					return
+				end
 
-        local path = vim.fn.expand("%:p:h")
-        vim.fn.jobstart({ "code", path }, { detach = true })
-      end,
-      desc = "VSCode: Open folder.",
-    },
-    { "<Leader>w/", group = "Search" },
-    {
-      "<Leader>w/*",
-      require("telescope.builtin").grep_string,
-      desc = "⭐︎Telescope: Search for the string under your cursor in Workspace.",
-      mode = { "n", "v" },
-    },
-    { "<Leader>w//", require("telescope.builtin").live_grep, desc = "⭐︎Telescope: Search in Workspace." },
-  })
+				local path = vim.fn.expand("%:p:h")
+				vim.fn.jobstart({ "code", path }, { detach = true })
+			end,
+			desc = "VSCode: Open folder.",
+		},
+		{ "<Leader>w/", group = "Search" },
+		{
+			"<Leader>w/*",
+			require("telescope.builtin").grep_string,
+			desc = "⭐︎Telescope: Search for the string under your cursor in Workspace.",
+			mode = { "n", "v" },
+		},
+		{ "<Leader>w//", require("telescope.builtin").live_grep, desc = "⭐︎Telescope: Search in Workspace." },
+	})
 end
 
 return {
-  "folke/which-key.nvim",
-  cond = condition,
-  event = "VeryLazy",
-  init = function()
-    vim.o.timeout = true
-    vim.o.timeoutlen = 300
-  end,
-  config = function()
-    local wk = require("which-key")
-    wk.setup()
+	"folke/which-key.nvim",
+	cond = condition,
+	event = "VeryLazy",
+	init = function()
+		vim.o.timeout = true
+		vim.o.timeoutlen = 300
+	end,
+	config = function()
+		local wk = require("which-key")
+		wk.setup()
 
-    -- キーの登録関数
-    -- <Leader>キーの次の文字で分類
-    registerLanguageKey() -- L"a"nguage
-    registerBufferKey()
-    registerCommandKey()
-    registerCommandPalletKey()
-    registerEditKey()
-    registerFileKey()
-    registerGitKey()
-    registerLspAndLlmKey()
-    registerMarkKey()
-    registerOutlineKey()
-    registerQuickfixAndLocation()
-    registerWorkspaceKey()
-    registerTerminalAndToolsKey()
-  end,
+		-- キーの登録関数
+		-- <Leader>キーの次の文字で分類
+		registerLanguageKey() -- L"a"nguage
+		registerBufferKey()
+		registerCommandKey()
+		registerCommandPalletKey()
+		registerEditKey()
+		registerFileKey()
+		registerGitKey()
+		registerLspAndLlmKey()
+		registerMarkKey()
+		registerOutlineKey()
+		registerQuickfixAndLocation()
+		registerWorkspaceKey()
+		registerTerminalAndToolsKey()
+	end,
 }

--- a/.config/nvim/lua/plugins/which-key.lua
+++ b/.config/nvim/lua/plugins/which-key.lua
@@ -9,17 +9,30 @@
 -- vscodeから呼び出す場合は利用しない
 local condition = vim.g.vscode == nil
 
+-- cluade codeコマンドのターミナルを開閉
+--
+-- dependencies: `akinsho/toggleterm.nvim`
+local function claudeCodeToggle()
+	local Terminal = require("toggleterm.terminal").Terminal
+	local cc = Terminal:new({
+		cmd = "claude",
+		direction = "float",
+		hidden = true,
+	})
+	cc:toggle()
+end
+
 -- gh dashコマンドのターミナルを開閉
 --
 -- dependencies: `akinsho/toggleterm.nvim`
 local function ghDashToggle()
 	local Terminal = require("toggleterm.terminal").Terminal
-	local lazygit = Terminal:new({
+	local ghDash = Terminal:new({
 		cmd = "gh dash",
 		direction = "float",
 		hidden = true,
 	})
-	lazygit:toggle()
+	ghDash:toggle()
 end
 
 -- lazygitコマンドのターミナルを開閉
@@ -754,16 +767,11 @@ local function registerLspAndLlmKey()
 		},
 		{
 			"<Leader>lur",
-			"<cmd>ClaudeCodeContinue<CR>",
-			desc = "ClaudeCode: Resume the most recent conversation.",
-			mode = { "n" },
-		},
-		{
-			"<Leader>lur",
 			"<cmd>ClaudeCodeResume<CR>",
 			desc = "ClaudeCode: Display an interactive conversation picker.",
 			mode = { "n" },
 		},
+		{ "<Leader>lut", claudeCodeToggle, desc = "⭐︎ToggleTerm: Open claude code." },
 	})
 
 	-- LspAttachしたときのみ設定を追加

--- a/.config/raycast/scripts/toggle-microphone.sh
+++ b/.config/raycast/scripts/toggle-microphone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Microphone
+# @raycast.mode silent
+
+# Optional parameters:
+# @raycast.icon 🤖
+# @raycast.packageName System
+
+# 現在の入力ボリュームを取得
+current_volume=$(osascript -e "input volume of (get volume settings)")
+
+if [ "$current_volume" -eq 0 ]; then
+  osascript -e "set volume input volume 50"
+  echo "Unmute"
+else
+  osascript -e "set volume input volume 0"
+  echo "Mute"
+fi
+

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -42,6 +42,15 @@ bind V split-window -h -c "#{pane_current_path}"
 bind s split-window -v
 bind S split-window -v -c "#{pane_current_path}"
 
+# paneのlayout変更
+# <prefix>l + keyで設定可能
+bind l   switch-client -T layout
+bind -T layout h select-layout main-horizontal
+bind -T layout H select-layout even-horizontal
+bind -T layout t select-layout tiled
+bind -T layout v select-layout main-vertical
+bind -T layout V select-layout even-vertical
+
 # tree setting
 bind a choose-tree
 bind e choose-session

--- a/setup.sh
+++ b/setup.sh
@@ -87,6 +87,8 @@ fi
 if type gh > /dev/null 2>&1; then
   gh extension install dlvhdr/gh-dash
   create_symlink $SCRIPT_DIR/.config/gh-dash/config.yml $HOME/.config/gh-dash/config.yml
+
+  gh extension install kmtym1998/gh-prowl
 fi
 # === git
 if type git > /dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -84,6 +84,11 @@ if type $HOME/.claude/local/claude > /dev/null 2>&1; then
   create_symlink $SCRIPT_DIR/.config/gemini/GEMINI.md $HOME/.gemini/GEMINI.md
 fi
 # === git
+if type gh > /dev/null 2>&1; then
+  gh extension install dlvhdr/gh-dash
+  create_symlink $SCRIPT_DIR/.config/gh-dash/config.yml $HOME/.config/gh-dash/config.yml
+fi
+# === git
 if type git > /dev/null 2>&1; then
   create_symlink $SCRIPT_DIR/.gitconfig $HOME/.gitconfig
   create_symlink $SCRIPT_DIR/.config/git/ignore $HOME/.config/git/ignore


### PR DESCRIPTION
- **:art: gh dashの設定ファイルをリンクするように修正**
- **:art: gh prowl extensionをインストールコマンドに追加**
- **:sparkles: add gh dash shortcut on neovim.**
- **:recycle: claude codeをmiseインストール版を利用するように修正**
- **:sparkles: neovim環境でclaude codeをtoggle termで開くコマンドを追加**
- **:fire: remove only-switch app on mac.**
- **:art: add all pr tab on gh dash.**
- **:sparkles: raycastでmicrophoneをmute/unmuteするスクリプトを追加**
- **:fire: mute keyをmac環境から削除**
- **:sparkles: add bash formatter and linter on neovim.**
- **:art: tmuxで画面分割のショートカットキーを追加**
- **:sparkles: claude codeのccusageのstatus lineを追加**
- **:art: gemini researchのプロンプトを修正**
