### PR TITLE
feat: :sparles: add raycast obs start/stop scripts

### DIFF
--- a/.config/raycast/scripts/obs-start.py
+++ b/.config/raycast/scripts/obs-start.py
@@ -1,0 +1,107 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "obsws-python",
+# ]
+# ///
+
+"""Start or connect to OBS and begin recording a configured scene."""
+
+import logging
+import subprocess
+import time
+
+from obsws_python import ReqClient
+
+_DEBUG = False
+
+# logging setup
+_log_level = logging.INFO if not _DEBUG else logging.DEBUG
+_log_format = "" if not _DEBUG else "%(asctime)s - %(levelname)s - %(message)s"
+logging.basicConfig(level=_log_level, format=_log_format)
+_logger = logging.getLogger(__name__)
+
+
+class OBSStartError(Exception):
+    """Raised when OBS cannot be started or connected to."""
+
+    pass
+
+
+def _connect_obs(
+    host: str, port: int, password: str, retries: int = 5, delay: int = 2
+) -> ReqClient:
+    """Connect to OBS WebSocket, launching OBS if necessary and retrying.
+
+    Args:
+        host: Hostname for the OBS WebSocket (typically "localhost").
+        port: Port for the OBS WebSocket.
+        password: Password for the OBS WebSocket.
+        retries: Number of times to retry after starting OBS.
+        delay: Seconds to wait between retries.
+
+    Returns:
+        A connected ReqClient instance.
+
+    Raises:
+        OBSStartError: If unable to connect after the configured retries.
+    """
+    # 初回の接続は失敗しても続行
+    try:
+        client = ReqClient(host=host, port=port, password=password)
+        return client
+    except Exception:
+        pass
+
+    # 接続に失敗したので OBS を起動
+    try:
+        subprocess.run(["open", "-a", "OBS"], check=True)
+        time.sleep(3)  # OBS起動待ち
+    except Exception:
+        _logger.exception("Failed to start OBS")
+        return None
+
+    # 接続の再試行
+    for i in range(retries):
+        try:
+            client = ReqClient(host=host, port=port, password=password)
+            return client
+        except Exception as e:
+            if i < retries:
+                time.sleep(delay)
+                continue
+
+            raise OBSStartError("Failed to connect to OBS") from e
+
+
+def main() -> None:
+    """Main entry point to ensure OBS records the target scene."""
+    OBS_HOST = "localhost"
+    OBS_PORT = 24455
+    OBS_PASSWORD = "BW4RxC6oFlIqVSLw"
+
+    TARGET_SCENE = "MacScreenCapture"
+
+    # OBS への接続確立
+    client = _connect_obs(
+        host=OBS_HOST, port=OBS_PORT, password=OBS_PASSWORD, retries=5, delay=2
+    )
+    status = client.get_record_status()
+    if status.output_active:
+        _logger.info("Recording already in progress")
+        return
+
+    # 撮影するシーンに切り替え
+    client.set_current_program_scene(name=TARGET_SCENE)
+    time.sleep(0.5)
+
+    # 撮影開始
+    client.start_record()
+    _logger.info("Started recording")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        _logger.exception("Error occurred")

--- a/.config/raycast/scripts/obs-start.sh
+++ b/.config/raycast/scripts/obs-start.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+
+# @raycast.schemaVersion 1
+# @raycast.title OBS - Start
+# @raycast.mode silent
+# @raycast.packageName Audio Tools
+# @raycast.icon 🔴
+
+source ~/.zshrc
+
+local SCRIPT_DIR
+SCRIPT_DIR="$(cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+readonly SCRIPT_DIR
+
+local -r SCRIPT_PATH="$SCRIPT_DIR/obs-start.py"
+if [ ! -f "$SCRIPT_PATH" ]; then
+  log_error "$SCRIPT_PATH not found."
+  return 1
+fi
+
+uv run "$SCRIPT_PATH" "$@"

--- a/.config/raycast/scripts/obs-stop.py
+++ b/.config/raycast/scripts/obs-stop.py
@@ -1,0 +1,118 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "obsws-python",
+# ]
+# ///
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from obsws_python import ReqClient
+
+_DEBUG = False
+_format = ""
+if _DEBUG:
+    _format = "%(asctime)s - %(levelname)s - %(message)s"
+logging.basicConfig(level=logging.INFO, format=_format)
+_logger = logging.getLogger(__name__)
+
+
+def _get_input_args() -> str:
+    meeting_name = sys.argv[1]
+    if not meeting_name:
+        raise ValueError("Meeting name is required")
+
+    return meeting_name
+
+
+def _stop_recording(host: str, port: int, password: str) -> None:
+    client = ReqClient(host=host, port=port, password=password)
+    status = client.get_record_status()
+    if not status.output_active:
+        _logger.info("録画中ではありません。")
+        return
+
+    # OBS上のステータスが停止になるまで待機
+    client.stop_record()
+    for _ in range(20):
+        time.sleep(0.5)
+        if not client.get_record_status().output_active:
+            return
+
+    raise RuntimeError("Failed to stop recording in OBS.")
+
+
+def _search_latest_file(directory: Path, pattern: str) -> Path:
+    list_of_files = [f for f in directory.glob(pattern) if f.is_file()]
+
+    if len(list_of_files) == 0:
+        raise RuntimeError("録画ファイルなし")
+
+    latest_file = max(list_of_files, key=os.path.getctime)
+
+    return latest_file
+
+
+def _wait_for_file_unlock(file_path: Path) -> None:
+    # lsofコマンドでOSレベルのファイルロックを確認（安全装置）
+    for _ in range(60):
+        if os.system(f"lsof '{file_path.absolute()}' > /dev/null 2>&1") != 0:
+            return
+        time.sleep(1)
+
+    raise RuntimeError("File is still locked after waiting.")
+
+
+def _get_destination_path(src: Path, dst_dir: Path, meeting_name: str) -> Path:
+    created_ts = src.stat().st_ctime
+    t = time.localtime(created_ts)
+
+    date_str = time.strftime("%Y%m%d", t)
+    month_str = f"{t.tm_mon:02d}"
+    dest_dir = dst_dir / month_str / f"{date_str}-{meeting_name}"
+
+    ext = src.suffix
+    filepath = dest_dir / f"{meeting_name}{ext}"
+
+    return filepath
+
+
+def _quit_obs() -> None:
+    subprocess.run(["osascript", "-e", 'quit app "OBS"'])
+
+
+def main() -> None:
+    REC_DIR = Path("~/Movies").expanduser()
+    TARGET_DIR = Path("~/meeting_records").expanduser()
+
+    OBS_HOST = "localhost"
+    OBS_PORT = 24455
+    OBS_PASSWORD = "BW4RxC6oFlIqVSLw"
+
+    meeting_name = _get_input_args()
+
+    _stop_recording(host=OBS_HOST, port=OBS_PORT, password=OBS_PASSWORD)
+
+    latest_file = _search_latest_file(REC_DIR, "*.mov")
+    _wait_for_file_unlock(latest_file)
+
+    dest_file = _get_destination_path(
+        src=latest_file, dst_dir=TARGET_DIR, meeting_name=meeting_name
+    )
+    dest_file.parent.mkdir(parents=True, exist_ok=True)
+    latest_file.rename(dest_file)
+    _logger.info(f"保存完了: {dest_file}")
+
+    _quit_obs()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        _logger.exception("Error occurred")

--- a/.config/raycast/scripts/obs-stop.sh
+++ b/.config/raycast/scripts/obs-stop.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+
+# @raycast.schemaVersion 1
+# @raycast.title OBS - Stop
+# @raycast.mode silent
+# @raycast.packageName Audio Tools
+# @raycast.icon 🏁
+# @raycast.argument1 { "type": "text", "placeholder": "移動先のフォルダ名" }
+
+SCRIPT_DIR=
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+readonly SCRIPT_DIR
+
+SCRIPT_PATH="$SCRIPT_DIR/obs-stop.py"
+
+source ~/.zshrc
+uv run "$SCRIPT_PATH" "$@"


### PR DESCRIPTION
- raycast: add zsh wrappers with Raycast metadata for start and stop
commands
- obs: add Python controllers using obsws-python to start recording,
stop recording, and switch scenes
- files: safely stop recording, wait for file unlock, and move latest
.mov to ~/meeting_records with date-based folders
