### PR TITLE
fix: :bug: improve front matter search regex and command

### DIFF
--- a/.config/nvim/lua/front-matter-searcher.lua
+++ b/.config/nvim/lua/front-matter-searcher.lua
@@ -55,9 +55,9 @@ local M = {}
 -- ```
 local function getFrontMatter(select_query)
 	local command = [[
-rg --json --multiline --multiline-dotall --max-count=1 --color=never --no-line-number --heading '^---\n(.*?)^(---)' '.' |
+rg --pcre2 --json --multiline --multiline-dotall --max-count=1 --color=never --no-line-number -g '*.md' '\A---\n(.*?)\n---\n' . |
   jq -r 'select(.type == "match") | {path: .data.path.text, text: .data.lines.text | split("\n") | .[1:-2] | join("\n  ")} | "- path: \(.path)\n  \(.text)"' |
-  yq -p yaml]] .. " '" .. select_query .. " | @json'"
+  yq -p yaml -o json]] .. " '" .. select_query .. "'"
 	local data = vim.fn.system(command)
 	local metadata_table = vim.json.decode(data)
 


### PR DESCRIPTION
先頭以外の fornt matter にヒットしないように修正

- switch to pcre2 engine for more reliable pattern matching
- update regex pattern to use \A anchor and explicit newlines for better
front matter boundary detection
- add markdown file glob filter (-g '*.md') to narrow search scope
- simplify yq command output format by removing unnecessary @json
transformation
