### PR TITLE
feat: :sparkles: add work-sessions skill for session management

### DIFF
--- a/.config/copilot/skills/work-sessions/SKILL.md
+++ b/.config/copilot/skills/work-sessions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: work-sessions
+description: Manage markdown work-session files in .agent/work-sessions to save, resume, search, and update progress across Copilot or LLM sessions.
+---
+
+# Work Sessions
+
+## Contract
+
+- Use only the scripts shipped with this skill (do not read and edit memory file)
+- All commands require --root <path> to locate <root>/.agent/work-sessions
+- <filename> / <task_slug> inputs MUST be provided without .md extension
+- Avoid network calls.
+
+## Workflow
+
+### 既存のセッションの確認
+
+1. List sessions: `python3 scripts/list.py --root <root>`
+2. Read a session.
+
+   ```bash
+   # セッション内容の全体を確認する場合
+   python3 scripts/read.py --root <root> 20260109_implement_auth
+
+   # セッション内容の概要を確認する場合
+   python3 scripts/read.py --root <root> 20260109_implement_auth --description
+   ```
+
+### Create a new session
+
+Store each session as `{task_slug}` where `task_slug` is snake_case ASCII.
+
+```bash
+python3 scripts/create.py --root <root> implement_auth --title "implement auth" --description "Implement JWT auth"
+```
+
+### Update a session
+
+Update front matter values:
+
+```bash
+python3 scripts/update.py --root <root> 20260109_implement_auth --description "Implement JWT auth (token issuance done)"
+```
+
+Replace a section (keep its heading):
+
+```bash
+python3 scripts/replace.py --root <root> 20260109_implement_auth --section "Summary" --content "Did X\nDid Y"
+```
+
+Insert a new section:
+
+```bash
+# 特定のセクションの前に追加する場合
+python3 scripts/insert.py --root <root> 20260109_implement_auth --new-section "Progress" --level 2 --content "- Done A\n- Done B" --before "Summary"
+
+# 特定のセクションの後に追加する場合
+python3 scripts/insert.py --root <root> 20260109_implement_auth --new-section "Progress" --level 2 --content "- Done A\n- Done B" --after "Summary"
+
+# 末尾にセクションを追加する場合
+python3 scripts/insert.py --root <root> 20260109_implement_auth --new-section "Progress" --level 2 --content "- Done A\n- Done B"
+```
+
+Delete a section:
+
+```bash
+python3 scripts/delete.py --root <root> 20260109_implement_auth --section "Progress"
+```
+
+### Search across sessions
+
+```bash
+python3 scripts/search.py --root <root> "JWT"
+```
+
+### Delete a session
+
+```bash
+python3 scripts/delete.py --root <root> 20260109_implement_auth
+```

--- a/.config/copilot/skills/work-sessions/references/spec.md
+++ b/.config/copilot/skills/work-sessions/references/spec.md
@@ -1,0 +1,29 @@
+# Work Sessions spec
+
+This skill implements the repository-local work-session file format and operations described in `session_memory.md`.
+
+## Storage
+
+- Root directory: `.agent/work-sessions/`
+- Archive directory (excluded from list/search): `.agent/work-sessions/archive/`
+
+## Filename format
+
+- `{YYYYMMDD}_{task_slug}.md`
+- `task_slug` is snake_case ASCII (lowercase letters, digits, underscore)
+
+## Frontmatter
+
+Required keys (fixed):
+
+- `title` (string)
+- `description` (string)
+- `created` (RFC3339-like timestamp)
+
+## Body (recommended)
+
+- `# {title}`
+- `## Summary`
+- `## Context`
+- `## Next Steps`
+- `## Notes`

--- a/.config/copilot/skills/work-sessions/scripts/create.py
+++ b/.config/copilot/skills/work-sessions/scripts/create.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+from ws_common import (
+    build_frontmatter,
+    ensure_dirs,
+    normalize_filename,
+    sessions_dir,
+    validate_task_slug,
+    write_text,
+)
+
+
+DEFAULT_BODY_TEMPLATE = """# {title}
+
+## Summary
+
+## Context
+
+## Next Steps
+
+## Notes
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("task_slug")
+    ap.add_argument("--title")
+    ap.add_argument("--description")
+    ap.add_argument("--body")
+    args = ap.parse_args()
+
+    if not args.title:
+        print("Error: --title required")
+        return 1
+    if not args.description:
+        print("Error: --description required")
+        return 1
+
+    task_slug = normalize_filename(args.task_slug)
+    try:
+        validate_task_slug(task_slug)
+    except ValueError:
+        print("Error: Invalid task_slug format. Expected: snake_case")
+        return 1
+
+    # Generate YYYYMMDD from local date
+    date_prefix = datetime.now().strftime("%Y%m%d")
+    filename = f"{date_prefix}_{task_slug}"
+
+    ensure_dirs(args.root)
+    path = sessions_dir(args.root) / f"{filename}.md"
+    if path.exists():
+        print(f"Error: File already exists: {filename}")
+        return 1
+
+    fm = build_frontmatter(args.title, args.description)
+    body = args.body if args.body is not None else DEFAULT_BODY_TEMPLATE.format(title=args.title)
+
+    write_text(path, fm + body.rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/delete.py
+++ b/.config/copilot/skills/work-sessions/scripts/delete.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import (
+    build_frontmatter,
+    find_section,
+    load_session,
+    normalize_filename,
+    sessions_dir,
+    split_frontmatter,
+    write_text,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("filename")
+    ap.add_argument("--section")
+    args = ap.parse_args()
+
+    name = normalize_filename(args.filename)
+    path = sessions_dir(args.root) / f"{name}.md"
+    if not path.exists():
+        print(f"Error: File not found: {name}")
+        return 1
+
+    if args.section:
+        # Delete section
+        text = path.read_text(encoding="utf-8")
+        _, body = split_frontmatter(text)
+        parsed = load_session(path)
+
+        try:
+            start, end = find_section(body, args.section)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return 1
+
+        lines = body.splitlines()
+        body2 = "\n".join(lines[:start] + lines[end:]).lstrip("\n")
+
+        fm = build_frontmatter(
+            parsed.frontmatter.get("title", ""),
+            parsed.frontmatter.get("description", "")
+        )
+        write_text(path, fm + body2.rstrip() + "\n")
+        return 0
+    else:
+        # Delete file
+        path.unlink()
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/insert.py
+++ b/.config/copilot/skills/work-sessions/scripts/insert.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import (
+    build_frontmatter,
+    find_section,
+    load_session,
+    normalize_filename,
+    sessions_dir,
+    split_frontmatter,
+    write_text,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("filename")
+    ap.add_argument("--new-section", required=True)
+    ap.add_argument("--level", type=int, required=True)
+    ap.add_argument("--content", required=True)
+    ap.add_argument("--before")
+    ap.add_argument("--after")
+    args = ap.parse_args()
+
+    if args.before and args.after:
+        print("Error: Cannot specify both --before and --after")
+        return 1
+
+    if args.level < 1 or args.level > 6:
+        print("Error: Level must be 1-6")
+        return 1
+
+    name = normalize_filename(args.filename)
+    path = sessions_dir(args.root) / f"{name}.md"
+    if not path.exists():
+        print(f"Error: File not found: {name}")
+        return 1
+
+    text = path.read_text(encoding="utf-8")
+    _, body = split_frontmatter(text)
+    parsed = load_session(path)
+
+    lines = body.splitlines()
+    hdr = "#" * args.level + " " + args.new_section
+    insert_block = [hdr, "", args.content.rstrip(), ""]
+
+    if args.before or args.after:
+        base_name = args.before if args.before else args.after
+        try:
+            start, end = find_section(body, base_name)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return 1
+
+        if args.before:
+            idx = start
+        else:
+            idx = end
+
+        body2 = "\n".join(lines[:idx] + insert_block + lines[idx:]).lstrip("\n")
+    else:
+        # Append to end
+        body2 = "\n".join(lines + [""] + insert_block).lstrip("\n")
+
+    fm = build_frontmatter(
+        parsed.frontmatter.get("title", ""),
+        parsed.frontmatter.get("description", "")
+    )
+    write_text(path, fm + body2.rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/list.py
+++ b/.config/copilot/skills/work-sessions/scripts/list.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import sessions_dir
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    args = ap.parse_args()
+
+    d = sessions_dir(args.root)
+    if not d.exists():
+        print("Error: .agent/work-sessions/ not found")
+        return 1
+
+    files = sorted(p for p in d.glob("*.md") if p.is_file() and p.parent == d)
+    if not files:
+        print("No sessions found")
+        return 0
+
+    for p in files:
+        print(p.name)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/read.py
+++ b/.config/copilot/skills/work-sessions/scripts/read.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import load_session, normalize_filename, sessions_dir, split_frontmatter
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("filename")
+    ap.add_argument("--description", action="store_true")
+    args = ap.parse_args()
+
+    name = normalize_filename(args.filename)
+    path = sessions_dir(args.root) / f"{name}.md"
+    if not path.exists():
+        print(f"Error: File not found: {name}")
+        return 1
+
+    if args.description:
+        s = load_session(path)
+        print(s.frontmatter.get("description", ""))
+        return 0
+
+    text = path.read_text(encoding="utf-8")
+    _, body = split_frontmatter(text)
+    print(body.lstrip("\n").rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/replace.py
+++ b/.config/copilot/skills/work-sessions/scripts/replace.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import (
+    find_section,
+    load_session,
+    normalize_filename,
+    sessions_dir,
+    split_frontmatter,
+    build_frontmatter,
+    write_text,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("filename")
+    ap.add_argument("--section", required=True)
+    ap.add_argument("--content", required=True)
+    args = ap.parse_args()
+
+    name = normalize_filename(args.filename)
+    path = sessions_dir(args.root) / f"{name}.md"
+    if not path.exists():
+        print(f"Error: File not found: {name}")
+        return 1
+
+    text = path.read_text(encoding="utf-8")
+    _, body = split_frontmatter(text)
+    parsed = load_session(path)
+
+    try:
+        start, end = find_section(body, args.section)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+
+    lines = body.splitlines()
+    heading = lines[start]
+    new_lines = [heading, "", args.content.rstrip(), ""]
+    body2 = "\n".join(lines[:start] + new_lines + lines[end:]).lstrip("\n")
+
+    fm = build_frontmatter(
+        parsed.frontmatter.get("title", ""),
+        parsed.frontmatter.get("description", "")
+    )
+    write_text(path, fm + body2.rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/search.py
+++ b/.config/copilot/skills/work-sessions/scripts/search.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+from ws_common import sessions_dir
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("keyword", nargs="?")
+    args = ap.parse_args()
+
+    if not args.keyword:
+        print("Error: Keyword required")
+        return 1
+
+    keyword = args.keyword
+    d = sessions_dir(args.root)
+    if not d.exists():
+        print("Error: .agent/work-sessions/ not found")
+        return 1
+
+    rg = shutil.which("rg")
+    if rg:
+        cmd = [
+            rg,
+            "--line-number",
+            "--no-heading",
+            "--glob",
+            "*.md",
+            "--glob",
+            "!archive/**",
+            keyword,
+            str(d),
+        ]
+        p = subprocess.run(cmd, text=True, capture_output=True)
+        out = (p.stdout or "").rstrip()
+        if out:
+            prefix = str(d).rstrip("/") + "/"
+            lines = []
+            for line in out.splitlines():
+                if line.startswith(prefix):
+                    line = line[len(prefix) :]
+                # Skip archive lines
+                if line.startswith("archive/"):
+                    continue
+                # rg format: file:line:match
+                parts = line.split(":", 2)
+                if len(parts) == 3:
+                    line = f"{parts[0]}:{parts[1]}: {parts[2]}"
+                lines.append(line)
+            if lines:
+                print("\n".join(lines))
+                return 0
+        print("No results found")
+        return 0
+
+    # Fallback: minimal Python search
+    results = []
+    for path in d.glob("*.md"):
+        if not path.is_file() or path.parent != d:
+            continue
+        for idx, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if keyword in line:
+                results.append(f"{path.name}:{idx}: {line}")
+
+    if results:
+        print("\n".join(results))
+        return 0
+
+    print("No results found")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/update.py
+++ b/.config/copilot/skills/work-sessions/scripts/update.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ws_common import (
+    build_frontmatter,
+    load_session,
+    normalize_filename,
+    sessions_dir,
+    split_frontmatter,
+    write_text,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--root", required=True, type=Path)
+    ap.add_argument("filename")
+    ap.add_argument("--title")
+    ap.add_argument("--description")
+    args = ap.parse_args()
+
+    name = normalize_filename(args.filename)
+    path = sessions_dir(args.root) / f"{name}.md"
+    if not path.exists():
+        print(f"Error: File not found: {name}")
+        return 1
+
+    text = path.read_text(encoding="utf-8")
+    _, body = split_frontmatter(text)
+    parsed = load_session(path)
+
+    title = args.title if args.title is not None else parsed.frontmatter.get("title", "")
+    description = args.description if args.description is not None else parsed.frontmatter.get("description", "")
+
+    fm = build_frontmatter(title, description)
+    write_text(path, fm + body.lstrip("\n").rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/copilot/skills/work-sessions/scripts/ws_common.py
+++ b/.config/copilot/skills/work-sessions/scripts/ws_common.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+RE_TASK_SLUG = re.compile(r"^[a-z0-9_]+$")
+RE_HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+
+
+def sessions_dir(root: Path) -> Path:
+    """Return the .agent/work-sessions directory under the given root."""
+    return root / ".agent" / "work-sessions"
+
+
+def normalize_filename(name: str) -> str:
+    """Remove .md extension if present."""
+    name = name.strip()
+    if name.endswith(".md"):
+        name = name[: -len(".md")]
+    return name
+
+
+def validate_task_slug(slug: str) -> None:
+    """Validate that task_slug is snake_case ASCII."""
+    if not RE_TASK_SLUG.match(slug):
+        raise ValueError("Invalid task_slug format. Expected: snake_case")
+
+
+@dataclass
+class ParsedSession:
+    frontmatter: Dict[str, str]
+    body: str
+
+
+def split_frontmatter(text: str) -> Tuple[str, str]:
+    """Return (frontmatter_raw, body)."""
+    if not text.startswith("---\n"):
+        raise ValueError("Missing YAML frontmatter")
+
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise ValueError("Invalid frontmatter format")
+
+    fm = text[4:end]
+    body = text[end + len("\n---\n") :]
+    return fm, body
+
+
+def parse_frontmatter(fm_raw: str) -> Dict[str, str]:
+    """Parse YAML-like frontmatter into dict."""
+    fm: Dict[str, str] = {}
+    for line in fm_raw.splitlines():
+        if not line.strip():
+            continue
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            continue
+        key = m.group(1)
+        val = m.group(2).strip()
+        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+            val = val[1:-1]
+        fm[key] = val
+    return fm
+
+
+def build_frontmatter(title: str, description: str) -> str:
+    """Build frontmatter string with title and description only."""
+    return "\n".join(
+        [
+            "---",
+            f"title: {title}",
+            f"description: {description}",
+            "---",
+            "",
+        ]
+    )
+
+
+def ensure_dirs(root: Path) -> None:
+    """Ensure .agent/work-sessions and archive/ directories exist."""
+    d = sessions_dir(root)
+    (d / "archive").mkdir(parents=True, exist_ok=True)
+
+
+def load_session(path: Path) -> ParsedSession:
+    """Load and parse a session file."""
+    text = path.read_text(encoding="utf-8")
+    fm_raw, body = split_frontmatter(text)
+    fm = parse_frontmatter(fm_raw)
+    return ParsedSession(frontmatter=fm, body=body)
+
+
+def find_section(body: str, name: str) -> Tuple[int, int]:
+    """
+    Find section by exact heading match (case-insensitive).
+    Return (start_line_idx, end_line_idx_exclusive).
+    """
+    lines = body.splitlines()
+
+    name_lower = name.strip().lower()
+    start = None
+    start_level = None
+    
+    for i, line in enumerate(lines):
+        m = RE_HEADING.match(line)
+        if not m:
+            continue
+        title = m.group(2).strip().lower()
+        if title == name_lower:
+            start = i
+            start_level = len(m.group(1))
+            break
+
+    if start is None or start_level is None:
+        raise ValueError(f"Section not found: {name}")
+
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        m2 = RE_HEADING.match(lines[j])
+        if not m2:
+            continue
+        level2 = len(m2.group(1))
+        if level2 <= start_level:
+            end = j
+            break
+
+    return start, end
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write text to file."""
+    path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Related URLs

## Changes
- work-sessionsスキルを追加し、.agent/work-sessionsディレクトリ内のマークダウン形式のワークセッションファイルを管理
- セッションの作成、読み込み、更新、検索、削除機能を提供
- Copilot または LLM セッション間で作業の進捗を保存・再開可能
- Front matter (YAML) によるメタデータ管理
- セクション単位での内容の置換、挿入、削除をサポート
- セッション横断検索機能を実装

## Confirmation Results
- すべてのスクリプトが--rootパラメータで動作することを確認
- セッションのCRUD操作が正常に動作することを確認
- 検索機能が複数セッションにわたって動作することを確認

## Review Points
- スクリプトのエラーハンドリング
- ファイル名の命名規則（task_slugの形式）
- Front matter の構造と必須フィールド
- セクション操作の一貫性

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->