### PR TITLE
feat: :sparkles: add Copilot skills directory to allowed paths

### DIFF
--- a/.config/nvim/lua/plugins/sidekick.lua
+++ b/.config/nvim/lua/plugins/sidekick.lua
@@ -42,6 +42,8 @@ return {
 							"--deny-tool=shell(rm -rf:*)",
 							"--deny-tool=shell(sudo:*)",
 							"--allow-all-tools",
+							-- 共通 skills のアクセスチェックが入るため
+							"--add-dir=~/.config/.copilot/skills",
 						},
 						env = github_copilot_token(),
 					},


### PR DESCRIPTION
## Related URLs

## Changes
- sidekick.nvim の設定に `~/.config/.copilot/skills` ディレクトリへのアクセス許可を追加
- `--add-dir` パラメータを使用して共有スキルディレクトリへのアクセスチェックを有効化
- これにより、Copilot スキルが正しく動作するようになる

## Confirmation Results
- 設定ファイルの変更内容を確認
- sidekick.lua に2行の追加のみ

## Review Points
- `--add-dir` パラメータの指定パスが正しいか
- 他のセキュリティ設定との整合性

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->

## 背景

sidekick.nvim で Copilot スキル機能を使用する際、スキルディレクトリへのアクセスチェックが必要となります。このPRでは、`~/.config/.copilot/skills` を許可パスに追加することで、共通スキルが正常に動作するようにします。