### PR TITLE
feat: :sparkles: サイドキックにコミットとPR作成用のカスタムプロンプトを追加

### DIFF
--- a/.config/nvim/lua/plugins/sidekick.lua
+++ b/.config/nvim/lua/plugins/sidekick.lua
@@ -66,6 +66,18 @@ return {
 						env = github_copilot_token(),
 					},
 				},
+				prompts = {
+					commit = ""
+						.. "Commit ONLY the already staged changes using the commit message generator agent. "
+						.. "Be sure to start the agent and use the skill through the agent. "
+						.. "Do not start the skill directly.",
+					pr_create = ""
+						.. "Create a pull request based on the changes in the current branch. "
+						.. "Use the 'create pr' agent to generate the pull request. "
+						.. "Write the pull request description in Japanese. "
+						.. "Be sure to start the agent and use the skill through the agent. "
+						.. "Do not start the skill directly.",
+				},
 			},
 		})
 	end,


### PR DESCRIPTION
## Related URLs

## Changes
- Neovimのsidekick.luaプラグイン設定にカスタムプロンプトセクションを追加
- コミット用プロンプト: ステージされた変更をcommit-message-generatorエージェント経由でコミット
- PR作成用プロンプト: create-prエージェント経由でプルリクエストを作成し、説明を日本語で記述
- 両プロンプトともスキルを直接起動せず、エージェント経由での実行を明示

## Confirmation Results
- Neovim設定ファイルの構文が正しいことを確認
- プロンプト定義がsidekickプラグインの仕様に準拠していることを確認

## Review Points
- プロンプトの文言が明確で理解しやすいか
- エージェントとスキルの使い分けが適切に説明されているか
- 日本語表記の指示が適切か

## Limitations
- この設定はNeovimのsidekickプラグイン環境でのみ有効
- 実際のエージェント・スキル動作は別途実装が必要