### PR TITLE
feat: :sparkles: add YAML language server support to Neovim

### DIFF
--- a/.config/nvim/after/lsp/yamlls.lua
+++ b/.config/nvim/after/lsp/yamlls.lua
@@ -1,0 +1,43 @@
+-- YAML Language Server設定
+--
+-- see: <https://github.com/redhat-developer/yaml-language-server>
+
+---@type vim.lsp.Config
+return {
+	settings = {
+		yaml = {
+			-- バリデーション、補完、ホバー情報を有効化
+			validate = true,
+			completion = true,
+			hover = true,
+
+			-- フォーマット設定は Conform で行うので無効化
+			format = {
+				enable = false,
+			},
+
+			-- SchemaStoreから自動でスキーマを取得
+			schemaStore = {
+				enable = true,
+				url = "https://www.schemastore.org/api/json/catalog.json",
+			},
+			-- 個別スキーマ指定
+			schemas = {
+				-- Docker Compose
+				["https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json"] = {
+					"docker-compose*.yml",
+					"docker-compose*.yaml",
+					"compose*.yml",
+					"compose*.yaml",
+				},
+				-- GitHub Actions
+				["https://json.schemastore.org/github-workflow.json"] = "/.github/workflows/*",
+				-- Kubernetes
+				["https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.29.0/all.json"] = {
+					"k8s/**/*.yaml",
+					"k8s/**/*.yml",
+				},
+			},
+		},
+	},
+}

--- a/.config/nvim/lua/plugins/mason.lua
+++ b/.config/nvim/lua/plugins/mason.lua
@@ -65,6 +65,7 @@ return {
 					"taplo", -- TOML LSP
 					-- "tsp-server ", -- Typespec LSP(手動でのみインストールできた)
 					"vtsls", -- Javascript and Typescript LSP
+					"yamlls", -- YAML LSP
 				},
 				auto_update = true,
 				run_on_start = true,


### PR DESCRIPTION
## Related URLs

## Changes
- Mason の ensure_installed リストに yamlls を追加
- yaml-language-server の設定ファイルを作成 (.config/nvim/after/lsp/yamlls.lua)
- SchemaStore との統合による自動スキーマ検出を有効化
- GitHub Actions、Docker Compose、Kubernetes などの YAML ファイルをサポート

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points
- yamlls の設定内容（検証、補完、ホバー、フォーマット機能）
- SchemaStore 統合の動作確認
- 既存の LSP 設定パターン（after/lsp/{lsp_name}.lua）との整合性

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->