### PR TITLE
build: :building_construction: luarocksプラグインにdkjson依存関係の自動インストール機能を追加

### DIFF
--- a/.config/nvim/lua/plugins/lualocks.lua
+++ b/.config/nvim/lua/plugins/lualocks.lua
@@ -9,4 +9,8 @@ return {
 	"vhyrro/luarocks.nvim",
 	priority = 1000, -- Very high priority is required, luarocks.nvim should run as the first plugin in your config.
 	config = true,
+	build = function()
+		require("luarocks").setup()
+		vim.fn.system("luarocks --tree=" .. vim.fn.stdpath("data") .. "/lazy/luarocks.nvim/.rocks install dkjson")
+	end,
 }


### PR DESCRIPTION
## Related URLs

## Changes
- luarocks.nvimプラグインにビルドステップを追加
- ビルド時にdkjsonパッケージを自動的にインストールするように設定
- luarocks setupを実行してから必要な依存関係をインストール

## Confirmation Results
- ビルドステップが正常に実行されることを確認
- dkjsonパッケージが適切にインストールされることを確認

## Review Points
- ビルドステップの実行タイミング
- luarocksのツリーパスの設定が適切か
- エラーハンドリングの必要性

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->