### PR TITLE
chore: :wrench: increase GPG agent cache timeout values

### DIFF
--- a/.config/gnupg/gpg-agent.conf
+++ b/.config/gnupg/gpg-agent.conf
@@ -1,3 +1,3 @@
 # パスフレーズのキャッシュ時間 (秒)
-default-cache-ttl 600
-max-cache-ttl 900
+default-cache-ttl 3600
+max-cache-ttl 7200


### PR DESCRIPTION
- extend default-cache-ttl from 600 to 3600 seconds (1 hour)
- extend max-cache-ttl from 900 to 7200 seconds (2 hours)
