### PR TITLE
docs: :memo: リポジトリルートディレクトリからの実行要件を明記

### DIFF
--- a/.config/copilot/skills/commit-staged/SKILL.md
+++ b/.config/copilot/skills/commit-staged/SKILL.md
@@ -16,6 +16,19 @@ Standardized git commits following Conventional Commits 1.0.0 with type validati
 - Description must be natural-language summary (not file paths)
 - Subject/body in English; subject is imperative, no trailing period
 
+**IMPORTANT**: All scripts must be executed from the **git repository root directory** where you want to commit changes.
+
+```bash
+# Incorrect usage - executing from skill directory
+# May operate on wrong repo!
+cd /path/to/skills/commit-staged
+bash scripts/commit.sh --type feat --description "add feature"
+
+# Correct usage - execute from target repository
+cd /path/to/your/repo
+bash /path/to/skills/commit-staged/scripts/commit.sh --type feat --description "add feature"
+```
+
 ## Workflow
 
 1. Review staged changes:
@@ -35,16 +48,19 @@ Standardized git commits following Conventional Commits 1.0.0 with type validati
 ## Scripts
 
 **staged-files.sh** - Show staged files and diff:
+
 ```bash
 bash scripts/staged-files.sh
 ```
 
 **commit.sh** - Execute commit with validation:
+
 ```bash
 bash scripts/commit.sh --type <type> --description <description> [--body <body>]
 ```
 
 Parameters:
+
 - `--type`: Required. Valid types in `references/types.md`
 - `--description`: Required. Natural language summary (max 100 chars with type/emoji)
 - `--body`: Optional. Bullet points starting with "-"
@@ -59,11 +75,13 @@ Parameters:
 ## Examples
 
 Simple commit:
+
 ```bash
 bash scripts/commit.sh --type feat --description "add user authentication"
 ```
 
 With body:
+
 ```bash
 bash scripts/commit.sh \
   --type fix \


### PR DESCRIPTION
## Related URLs

## Changes
- commit-stagedスキルのドキュメントに、スクリプトをリポジトリルートディレクトリから実行する必要があることを追加
- 誤った使用例と正しい使用例を示すコードブロックを追加
- スキルディレクトリから実行すると誤ったリポジトリで操作される可能性があることを警告

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points
- ドキュメントの構成と配置
- 使用例の明確さ
- 警告メッセージの適切性

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->