### PR TITLE
ci: add Copilot coding agent setup steps workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,31 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      MISE_IGNORED_CONFIG_PATHS: ${{ github.workspace }}/.config/mise/config-mac.toml:${{ github.workspace }}/.config/mise/config-linux.toml:${{ github.workspace }}/.config/mise/config-codespaces.toml
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+
+      - name: Set up Copilot agent configurations
+        run: |
+          mkdir -p ~/.copilot
+          ln -s "$GITHUB_WORKSPACE/.config/copilot/agents" ~/.copilot/agents
+          ln -s "$GITHUB_WORKSPACE/.config/copilot/skills" ~/.copilot/skills

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,9 +20,9 @@ jobs:
       MISE_IGNORED_CONFIG_PATHS: ${{ github.workspace }}/.config/mise/config-mac.toml:${{ github.workspace }}/.config/mise/config-linux.toml:${{ github.workspace }}/.config/mise/config-codespaces.toml
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
 
       - name: Set up Copilot agent configurations
         run: |


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/157

## Changes
- Create .github/workflows/copilot-setup-steps.yml for Copilot coding agent setup
- Install mise tools (shellcheck, shfmt, prettier, markdownlint-cli2, taplo, lefthook, bash-language-server, lua-language-server) via mise-action
- Create symlinks for ~/.copilot/agents and ~/.copilot/skills from .config/copilot/
- Exclude platform-specific mise configs (mac, linux, codespaces) from auto-discovery
- Upgrade actions/checkout to v6.0.2 and jdx/mise-action to v4.0.0 for Node.js 24 support

## Confirmation Results
- Workflow ran successfully twice on CI (runs 23929549549 and 23930074196)
- No Node.js deprecation warnings after action version upgrades
- All 8 mise tools installed correctly
- Symlinks created at ~/.copilot/agents and ~/.copilot/skills

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->