### PR TITLE
refactor: migrate tools from Homebrew to mise and simplify fzf setup

### DIFF
--- a/.config/fzf/fzf.bash
+++ b/.config/fzf/fzf.bash
@@ -5,77 +5,11 @@
 # Gurad if command does not exist.
 if ! type fzf >/dev/null 2>&1; then return 0; fi
 
-if type brew >/dev/null 2>&1; then
-  FZF_CONFIG=${HOMEBREW_PREFIX}/opt/fzf/shell
-else
-  FZF_CONFIG=${FZF_CONFIG:-$HOME/.config/fzf}
-fi
-if [[ "$SHELL" == *zsh* ]]; then
-  FZF_COMPLETION="$FZF_CONFIG/completion.zsh"
-  FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.zsh"
-else
-  FZF_COMPLETION="$FZF_CONFIG/completion.bash"
-  FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.bash"
-fi
-# proot環境ではkey-bindingsの位置が異なるので修正
-if [[ "$(uname -r)" == *proot* ]]; then
-  FZF_CONFIG="/usr/share/doc/fzf/examples"
-  FZF_COMPLETION="/usr/share/bash-completion/completions/fzf"
-  FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.bash"
-fi
-# termux環境ではkey-bindingsの位置が異なるので修正
-if [[ "$(uname -r)" == *android* ]]; then
-  FZF_CONFIG="/data/data/com.termux/files/usr/share/fzf"
-  FZF_COMPLETION="$FZF_CONFIG/completion.bash"
-  FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.bash"
-fi
-# oracle(ubuntu24.04)でのkeybindings
-if [[ "$(uname -r)" == *oracle* ]]; then
-  if [[ "$SHELL" == *zsh* ]]; then
-    FZF_CONFIG="/usr/share/doc/fzf/examples"
-    FZF_KEYBINDINGS="$FZF_CONFIG/completion.zsh"
-    FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.zsh"
-  else
-    # bash
-    FZF_CONFIG="/usr/share/doc/fzf/examples"
-    FZF_KEYBINDINGS="/usr/share/bash-completion/completions/fzf"
-    FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.bash"
-  fi
-fi
-# github codespaces (= azure) で手動で key-bindings を設定
-if [[ "$(uname -r)" == *azure* ]]; then
-  FZF_CONFIG="$HOME/.config/fzf"
-  FZF_KEYBINDINGS="$FZF_CONFIG/completion.zsh"
-  FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.zsh"
-fi
-# wslでのkeybindings
-if [[ "$(uname -r)" == *WSL* ]]; then
-  if [[ "$SHELL" == *zsh* ]]; then
-    FZF_CONFIG="/usr/share/doc/fzf/examples"
-    FZF_KEYBINDINGS="$FZF_CONFIG/completion.zsh"
-    FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.zsh"
-  else
-    # bash
-    FZF_CONFIG="/usr/share/doc/fzf/examples"
-    FZF_KEYBINDINGS="/usr/share/bash-completion/completions/fzf"
-    FZF_KEYBINDINGS="$FZF_CONFIG/key-bindings.bash"
-  fi
-fi
-
-# Use tmux for selecting window if tmux exists..
-# tmuxがない場合は明示的に無効化する。macなどでarm64, amd64の切り替えをするときに環境がないのに有効化される。
-# if type tmux > /dev/null 2>&1; then
-#   export FZF_TMUX=1
-# else
-#   export FZF_TMUX=0
-# fi
 # tmuxを有効化するとfzfでCtrl+Rでコマンド選択した場合にtmuxウィンドウが停止する場合があったため、無効化する。
 export FZF_TMUX=0
 
-# Use fzf completion.
-if [ -f $FZF_COMPLETION ]; then . $FZF_COMPLETION 2>/dev/null; fi
-# Use fzf keybindings.
-if [ -f $FZF_KEYBINDINGS ]; then . $FZF_KEYBINDINGS; fi
+# Use fzf completion and keybindings
+. <(fzf --zsh)
 
 # Aliases.
 # Find repositories under golang directory structure
@@ -85,59 +19,59 @@ alias ffghq='cd $(find ${SOURCE_ROOT:-$HOME/src} -follow  -maxdepth ${FFGHQ_MAXD
 # find-in-file - usage: fif <searchTerm>
 # Ref: https://github.com/junegunn/fzf/wiki/examples#searching-file-contents
 fif() {
-  if [ ! "$#" -gt 0 ]; then
-    echo "Need a string to search for!"
-    return 1
-  fi
-  rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+	if [ ! "$#" -gt 0 ]; then
+		echo "Need a string to search for!"
+		return 1
+	fi
+	rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # find in file with hidden files.
 # find-in-file-with-hidden-file - usage: fifh <searchTerm>
 fifh() {
-  if [ ! "$#" -gt 0 ]; then
-    echo "Need a string to search for!"
-    return 1
-  fi
-  rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+	if [ ! "$#" -gt 0 ]; then
+		echo "Need a string to search for!"
+		return 1
+	fi
+	rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # Open the selected file with the default editor
 fo() {
-  local file
-  file=$(fif "")
-  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+	local file
+	file=$(fif "")
+	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # Find file with hidden, and open the selected file with the default editor
 foh() {
-  local file
-  file=$(fifh "")
-  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+	local file
+	file=$(fifh "")
+	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-and-open-it - usage: fog <searchTerm>
 fog() {
-  if [ ! "$#" -gt 0 ]; then
-    echo "Need a string to search for!"
-    return 1
-  fi
+	if [ ! "$#" -gt 0 ]; then
+		echo "Need a string to search for!"
+		return 1
+	fi
 
-  local file
-  file=$(fif $@)
-  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+	local file
+	file=$(fif $@)
+	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-with-hidden-file-and-open-it - usage: fog <searchTerm>
 fogh() {
-  if [ ! "$#" -gt 0 ]; then
-    echo "Need a string to search for!"
-    return 1
-  fi
+	if [ ! "$#" -gt 0 ]; then
+		echo "Need a string to search for!"
+		return 1
+	fi
 
-  local file
-  file=$(fifh $@)
-  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+	local file
+	file=$(fifh $@)
+	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }

--- a/.config/homebrew/Brewfile
+++ b/.config/homebrew/Brewfile
@@ -2,14 +2,14 @@
 
 # === application management
 brew "mas"
-cask "appcleaner"
+# cask "appcleaner"
 mas "RunCat", id: 1429033973
 
 # === communication tools
-cask "brave-browser"
+# cask "brave-browser"
 cask "firefox"
 cask "google-chrome"
-cask "slack"
+# cask "slack"
 mas "velja", id: 1607635845  # linkを開く際のブラウザ選択
 
 # === desktop management
@@ -19,85 +19,47 @@ cask "raycast"  # 検索 + rectangle
 cask "rancher"  # dockerd
 
 # === fonts
-cask "font-cica"
-cask "font-hack-nerd-font"
+# cask "font-cica"
+# cask "font-hack-nerd-font"
 cask "font-hackgen-nerd"
 
 # === git
 tap "microsoft/git"
 brew "git"
 brew "git-lfs"
-brew "lazygit"
 
 # === key management
-brew "stoken"  # pass generateor
 mas "bitwarden", id: 1352778147  # password manager(app store版を利用しないとブラウザの生体認証が利用できない)
 
 # === keyboard, mouse and trackpad management
 cask "azookey"
 cask "karabiner-elements"  # Alt単体押しによる日本語切り替え
 cask "scroll-reverser"  # マウスのみスクロール方向を逆転
-# cask "voiceink"  # instantly transcribe what you say
 cask "handy"  # speech-to-text application
 
 # === LLM
 cask "lm-studio"
 
-# === plantuml
-# brew "graphviz"
-# brew "plantuml"
-
 # === project
 brew "bash"
-brew "jq"
-# brew "pwgen"
-# brew "licensed"
 
 # === programming tools
-# brew "cargo-make"
-# brew "dprint"  # markdown formatter
-# brew "go-task"
 brew "mise"
-cask "obsidian"
-cask "visual-studio-code"
-cask "coteditor"
+# cask "visual-studio-code"
 
 # === recording
-brew "ffmpeg"
+# brew "ffmpeg"
 cask "obs"
 
-# === ruby
-# rubyをmiseでインストールするときに必要
-# brew "autoconf"
-# brew "gmp"
-# brew "libyaml"
-# brew "openssl@3"
-# brew "readline"
-
-# === rust
-# 2024-07-24 rustup-init -> rustupの変更タイミングで正常にインストールできなくなったので公式の方法に従う。
-# `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-# see: <https://www.rust-lang.org/ja/tools/install>
-# brew "rustup"
-
 # === terminal
-brew "bat"
 brew "cmake"
-brew "eza"  # replace ls -> exa -> eza
-brew "fd"  # replace find
-brew "fzf"  # fuzzy finder
 brew "gcc"
-brew "git-delta"  # diff viewer
-brew "gh"  # github cli
 cask "ghostty"
-brew "luarocks"  # for lazy.nvim plugin
+# brew "luarocks"  # for lazy.nvim plugin -> おそらく lua 導入で不要になっているはず
 brew "neovim"  # neovim
 brew "pkg-config"
-brew "pngpaste"  # for img-clip.nvim plugin
-brew "ripgrep"  # replace grep
+# brew "pngpaste"  # for img-clip.nvim plugin
 brew "starship"  # Shell prompt
 brew "tmux"
-brew "vifm"  # tui filer
+brew "vifm"
 brew "wget"
-brew "yq"
-# brew "zellij" # terminal multiplexers

--- a/.config/mise/config-mac.toml
+++ b/.config/mise/config-mac.toml
@@ -1,12 +1,20 @@
 [tools]
 awscli = { version = "latest", symlink_bins = "true" }
+bat = "0.26.1"
 cargo-binstall = "latest"
 "cargo:tree-sitter-cli" = "latest"                     # for neovim
+delta = "0.19.1"
+eza = "0.23.4"
+fd = "10.4.2"
+fzf = "0.70.0"
+gh = "2.88.1"
+"github:vifm/vifm" = "v0.14.3"
 go = "1"
+jq = "1.8.1"
+lazygit = "v0.60.0"
 lua = "5.1"                                            # neovim luarocksで要求しているバージョンが5.1
 node = "22"
 "npm:@aikidosec/safe-chain" = "latest"
-"npm:@anthropic-ai/sandbox-runtime" = "latest"
 "npm:@bitwarden/cli" = "latest"
 "npm:@github/copilot" = "latest"
 "npm:mcp-remote" = "latest"                            # for copilot
@@ -16,13 +24,15 @@ node = "22"
 "pipx:pynvim" = "latest"                               # for neovim
 pnpm = "latest"
 python = "3.13"
+ripgrep = "15.1.0"
 rust = "stable"
 shellcheck = "latest"
 shfmt = "latest"
 uv = "latest"
+yq = "4.52.5"
 
 [env]
-UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
+# UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
 
 [settings]
 activate_aggressive = true

--- a/.config/raycast/scripts/startup-mac.sh
+++ b/.config/raycast/scripts/startup-mac.sh
@@ -21,9 +21,9 @@ brew bundle --file ../../homebrew/Brewfile cleanup --force
 # ref: <https://qiita.com/bonji/items/183160eab52919aaf93e>
 # brew upgrade --cask --greedy
 mise up
-gh extension upgrade --all
+mise exec -- gh extension upgrade --all
 
-open -a "Scroll Reverser" # マウスによるscrollの逆転
+# open -a "Scroll Reverser" # マウスによるscrollの逆転
 
 # password and vpn
 # open -a Bitwarden # bitwardenの起動設定で対処
@@ -36,10 +36,10 @@ open -a "Microsoft Edge"
 # open -a "firefox"
 
 # communication tool
-open -a "Slack"
-open -a "OneDrive"
-open -a "Microsoft Teams"
-open -a "Microsoft Outlook"
+# open -a "Slack"
+# open -a "OneDrive"
+# open -a "Microsoft Teams"
+# open -a "Microsoft Outlook"
 
 # work tools
 open -a "Ghostty"

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -50,9 +50,9 @@ readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
 
 # === Install [homebrew](https://brew.sh/index_ja)
-if ! type brew >/dev/null 2>&1; then
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
+# if ! type brew >/dev/null 2>&1; then
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# fi
 
 # === Install softwaare
 # homebrewを利用するための設定を追記して再読み込み
@@ -123,7 +123,7 @@ if type vim >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/vim" "$HOME/.config/vim"
 fi
 # === copilot cli
-if type code >/dev/null 2>&1; then
+if type copilot >/dev/null 2>&1; then
   # Copilot CLI
   create_symlink "$SCRIPT_DIR/.config/copilot/agents" "$HOME/.copilot/agents"
   create_symlink "$SCRIPT_DIR/.config/copilot/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"


### PR DESCRIPTION
## Related URLs

## Changes
- move bat, delta, eza, fd, fzf, gh, jq, lazygit, ripgrep, yq, and vifm from Brewfile into mise mac config
- simplify fzf shell integration to use fzf --zsh instead of platform-specific path detection
- comment out Homebrew install block in setup_mac.sh
- fix copilot CLI symlink guard from code to copilot in setup_mac.sh
- update Raycast startup script to invoke gh via mise exec and remove auto-start for Slack and Microsoft apps

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->