### PR TITLE
ci: add Renovate for automated dependency updates

### DIFF
--- a/.config/mise/config-codespaces.toml
+++ b/.config/mise/config-codespaces.toml
@@ -1,21 +1,21 @@
 [tools]
-cargo-binstall = "latest"
-"cargo:tree-sitter-cli" = "latest"                       # for neovim
-go = "1"
-lua = "5.1"                                              # neovim luarocksで要求しているバージョンが5.1
-node = "22"
-"npm:@aikidosec/safe-chain" = "latest"
-"npm:mcp-remote" = "latest"                              # for copilot
-"npm:neovim" = "latest"                                  # for neovim
-"pipx:awslabs.aws-documentation-mcp-server" = "latest"
-"pipx:markitdown-mcp" = { version = "latest", all = "" } # for copilot
-"pipx:pynvim" = "latest"                                 # for neovim
-pnpm = "latest"
-python = "3.13"
-rust = "stable"
-shellcheck = "latest"
-shfmt = "latest"
-uv = "latest"
+cargo-binstall = "1.17.9"
+"cargo:tree-sitter-cli" = "0.26.8"                        # for neovim
+go = "1.26.1"
+lua = "5.1.5"                                             # neovim luarocksで要求しているバージョンが5.1
+node = "22.22.2"
+"npm:@aikidosec/safe-chain" = "1.4.7"
+"npm:mcp-remote" = "0.1.38"                               # for copilot
+"npm:neovim" = "5.4.0"                                    # for neovim
+"pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"
+"pipx:markitdown-mcp" = { version = "0.0.1a4", all = "" } # for copilot
+"pipx:pynvim" = "0.6.0"                                   # for neovim
+pnpm = "10.33.0"
+python = "3.13.12"
+rust = "1.94.1"
+shellcheck = "0.11.0"
+shfmt = "3.13.0"
+uv = "0.11.3"
 
 [settings]
 experimental = true

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -1,26 +1,26 @@
 [tools]
 aws-vault = "7.2.0"
-awscli = { version = "latest", symlink_bins = "true" }
-cargo-binstall = "latest"
-"cargo:tree-sitter-cli" = "latest"                       # for neovim
-go = "1"
-lua = "5.1"                                              # neovim luarocksで要求しているバージョンが5.1
-node = "24"
-"npm:@aikidosec/safe-chain" = "latest"
-"npm:@bitwarden/cli" = "latest"
-"npm:@github/copilot" = "latest"
-"npm:mcp-remote" = "latest"                              # for copilot
-"npm:neovim" = "latest"                                  # for neovim
-"pipx:awslabs.aws-documentation-mcp-server" = "latest"
-"pipx:markitdown-mcp" = { version = "latest", all = "" } # for copilot
-"pipx:oraios/serena" = "latest"                          # for copilot
-"pipx:pynvim" = "latest"                                 # for neovim
-pnpm = "latest"
-python = "3.13"
-rust = "stable"
-shellcheck = "latest"
-shfmt = "latest"
-uv = "latest"
+awscli = { version = "2.34.24", symlink_bins = "true" }
+cargo-binstall = "1.17.9"
+"cargo:tree-sitter-cli" = "0.26.8"                        # for neovim
+go = "1.26.1"
+lua = "5.1.5"                                             # neovim luarocksで要求しているバージョンが5.1
+node = "24.14.1"
+"npm:@aikidosec/safe-chain" = "1.4.7"
+"npm:@bitwarden/cli" = "2026.3.0"
+"npm:@github/copilot" = "1.0.17"
+"npm:mcp-remote" = "0.1.38"                               # for copilot
+"npm:neovim" = "5.4.0"                                    # for neovim
+"pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"
+"pipx:markitdown-mcp" = { version = "0.0.1a4", all = "" } # for copilot
+"pipx:oraios/serena" = "0.9.1"                            # for copilot
+"pipx:pynvim" = "0.6.0"                                   # for neovim
+pnpm = "10.33.0"
+python = "3.13.12"
+rust = "1.94.1"
+shellcheck = "0.11.0"
+shfmt = "3.13.0"
+uv = "0.11.3"
 
 [env]
 # UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }

--- a/.config/mise/config-mac.toml
+++ b/.config/mise/config-mac.toml
@@ -1,34 +1,34 @@
 [tools]
-awscli = { version = "latest", symlink_bins = "true" }
+awscli = { version = "2.34.24", symlink_bins = "true" }
 bat = "0.26.1"
-cargo-binstall = "latest"
-"cargo:tree-sitter-cli" = "latest"                     # for neovim
+cargo-binstall = "1.17.9"
+"cargo:tree-sitter-cli" = "0.26.8"                      # for neovim
 delta = "0.19.1"
 eza = "0.23.4"
 fd = "10.4.2"
 fzf = "0.70.0"
 gh = "2.88.1"
 "github:vifm/vifm" = "v0.14.3"
-go = "1"
+go = "1.26.1"
 jq = "1.8.1"
 lazygit = "v0.60.0"
-lua = "5.1"                                            # neovim luarocksで要求しているバージョンが5.1
-node = "22"
-"npm:@aikidosec/safe-chain" = "latest"
-"npm:@bitwarden/cli" = "latest"
-"npm:@github/copilot" = "latest"
-"npm:mcp-remote" = "latest"                            # for copilot
-"npm:neovim" = "latest"                                # for neovim
-"pipx:awslabs.aws-documentation-mcp-server" = "latest"
-"pipx:oraios/serena" = "latest"                        # for copilot
-"pipx:pynvim" = "latest"                               # for neovim
-pnpm = "latest"
-python = "3.13"
+lua = "5.1.5"                                           # neovim luarocksで要求しているバージョンが5.1
+node = "22.22.2"
+"npm:@aikidosec/safe-chain" = "1.4.7"
+"npm:@bitwarden/cli" = "2026.3.0"
+"npm:@github/copilot" = "1.0.17"
+"npm:mcp-remote" = "0.1.38"                             # for copilot
+"npm:neovim" = "5.4.0"                                  # for neovim
+"pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"
+"pipx:oraios/serena" = "0.9.1"                          # for copilot
+"pipx:pynvim" = "0.6.0"                                 # for neovim
+pnpm = "10.33.0"
+python = "3.13.12"
 ripgrep = "15.1.0"
-rust = "stable"
-shellcheck = "latest"
-shfmt = "latest"
-uv = "latest"
+rust = "1.94.1"
+shellcheck = "0.11.0"
+shfmt = "3.13.0"
+uv = "0.11.3"
 yq = "4.52.5"
 
 [env]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,32 @@
+name: Renovate
+
+on:
+  schedule:
+    # Run weekly on Saturday at 15:00 UTC (Sunday 00:00 JST)
+    - cron: "0 15 * * 6"
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: "Log level for Renovate"
+        type: choice
+        default: info
+        options:
+          - info
+          - debug
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-"aqua:LuaLS/lua-language-server" = "latest"
-"npm:bash-language-server" = "latest"
+"aqua:LuaLS/lua-language-server" = "3.18.0"
+"npm:bash-language-server" = "5.6.0"
 shfmt = "3.12.0"
 shellcheck = "0.11.0"
 "cargo:taplo-cli" = "0.10.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "aqua:LuaLS/lua-language-server" = "3.18.0"
 "npm:bash-language-server" = "5.6.0"
-shfmt = "3.12.0"
+shfmt = "3.13.0"
 shellcheck = "0.11.0"
 "cargo:taplo-cli" = "0.10.0"
 "npm:prettier" = "3.8.1"

--- a/renovate.json
+++ b/renovate.json
@@ -12,14 +12,28 @@
       "allowedVersions": "/^5\\.1\\./"
     },
     {
-      "description": "Group all mise tool updates into a single PR",
+      "description": "Group all mise major updates into a single PR",
       "matchManagers": ["mise"],
-      "groupName": "mise tools"
+      "matchUpdateTypes": ["major"],
+      "groupName": "mise tools (major)"
     },
     {
-      "description": "Group all GitHub Actions updates into a single PR",
+      "description": "Group all mise minor and patch updates into a single PR",
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "mise tools (minor/patch)"
+    },
+    {
+      "description": "Group all GitHub Actions major updates into a single PR",
       "matchManagers": ["github-actions"],
-      "groupName": "github actions"
+      "matchUpdateTypes": ["major"],
+      "groupName": "github actions (major)"
+    },
+    {
+      "description": "Group all GitHub Actions minor and patch updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "github actions (minor/patch)"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "14 days",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Constrain lua to 5.1.x for neovim compatibility",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["lua"],
+      "allowedVersions": "/^5\\.1\\./"
+    },
+    {
+      "description": "Group all mise tool updates into a single PR",
+      "matchManagers": ["mise"],
+      "groupName": "mise tools"
+    },
+    {
+      "description": "Group all GitHub Actions updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Related URLs

## Changes
- add renovate.json with best-practices preset, 14-day cooldown, lua 5.1.x constraint, and major/minor PR group split
- add self-hosted Renovate GitHub Actions workflow (Saturday 15:00 UTC / Sunday 00:00 JST)
- pin all mise tool versions from latest/partial to exact versions across 4 config files
- group PRs by ecosystem (mise/actions) and update type (major/minor+patch)

## Confirmation Results
- mise run lint passes
- mise run format passes
- rebased cleanly onto latest master (including PR #161 tools)

## Review Points
- renovate.json packageRules structure
- pinned version accuracy for newly added tools (bat, delta, eza, fd, fzf, gh, vifm, jq, lazygit, ripgrep, yq)

## Limitations
- RENOVATE_TOKEN secret must be manually created and registered after merge
- Renovate issue #30365 means partial version specs cannot be used

### Post-merge manual steps

1. Create a Fine-grained PAT with permissions: Contents, PRs, Issues, Commit statuses, Workflows (R/W), Dependabot alerts (R)
2. Register as RENOVATE_TOKEN in Settings > Secrets and variables > Actions