### PR TITLE
feat: integrate GitHub activity logs into daily-summary skill

### DIFF
--- a/.config/copilot/agents/daily-summary-activity.md
+++ b/.config/copilot/agents/daily-summary-activity.md
@@ -1,0 +1,106 @@
+---
+name: daily-summary-activity
+description: Summarize a single GitHub issue or PR from its full history.
+model: claude-sonnet-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["read", "search", "edit", "bash"]
+---
+
+# Daily Summary: Activity Analyzer
+
+## Overview
+
+Read a single GitHub issue or pull request in full and produce a structured
+summary focused on the user's activity within a specified date range. Fetch
+the complete history to understand context, then scope the summary to the
+target period.
+
+The caller provides these parameters:
+
+- `type`: `issue` or `pr`
+- `owner`: Repository owner
+- `repo`: Repository name
+- `number`: Issue or PR number
+- `date`: Start date of the target period (YYYY-MM-DD)
+- `end_date`: End date of the target period (YYYY-MM-DD)
+- `github_user`: GitHub username of the target user
+- `output_filepath`: Absolute path where the summary markdown file must be written
+
+## Procedure
+
+1. Fetch the full issue or PR with all comments and metadata.
+2. Read the complete history to understand the full context.
+3. Identify actions taken by `github_user` within the `date` to `end_date`
+   period (inclusive).
+4. Produce the summary in the output format below.
+
+### Fetching Data
+
+For issues:
+
+```bash
+gh issue view NUMBER --repo OWNER/REPO --json title,body,comments,labels,state,createdAt,closedAt,author,assignees,url
+```
+
+For pull requests:
+
+```bash
+gh pr view NUMBER --repo OWNER/REPO --json title,body,comments,reviews,files,labels,state,createdAt,closedAt,mergedAt,mergedBy,author,assignees,url,headRefName,baseRefName,additions,deletions
+```
+
+### Identifying User Activity
+
+Scan the full timeline for actions by `github_user` within the date range:
+
+- Comments authored by the user
+- Reviews submitted by the user (for PRs)
+- State changes (opened, closed, merged, reopened) by the user
+- Label or assignee changes by the user (if visible in comments)
+- Code changes pushed by the user (for PRs, visible in review comments or
+  commit references)
+
+If no activity by the user is found within the date range, still produce the
+summary but note that the user's involvement was indirect (mentioned,
+assigned, or subscribed).
+
+## Output
+
+Write the summary as a markdown file to `output_filepath`. Capture the full
+context while focusing on the target period. Write in the same language as
+the issue/PR content (Japanese if the content is in Japanese).
+
+```md
+# Activity Summary
+
+- Type: Issue | Pull Request
+- Repository: owner/repo
+- Number: #N
+- Title: Title text
+- URL: https://github.com/...
+- State: open | closed | merged
+- Branch: head-ref -> base-ref (PRs only, omit for issues)
+- Period: YYYY-MM-DD - YYYY-MM-DD
+
+## Context
+
+Brief overview of what this issue/PR is about, based on the full history.
+Include background and purpose so a reader unfamiliar with the project can
+understand the significance.
+
+## User Activity in Period
+
+- Specific action 1 with timestamp context
+- Specific action 2 with timestamp context
+
+## Outcomes
+
+- Concrete result or current status as of the period end
+
+## Decisions
+
+- Decision made during the period and its rationale
+```
+
+Omit the Decisions section if no decisions were identified during the period.
+Omit the Branch line for issues.

--- a/.config/copilot/agents/daily-summary-session.md
+++ b/.config/copilot/agents/daily-summary-session.md
@@ -53,6 +53,8 @@ final actions.
 - Branch: branch-name
 - Task: One-line description of what was being worked on
 - Status: completed | failed | abandoned | in-progress
+- Related Issues: [N, M] or empty []
+- Related PRs: [N, M] or empty []
 
 ## Outcomes
 
@@ -69,3 +71,8 @@ final actions.
 ```
 
 Omit Decisions or Issues sections if none were identified.
+
+Populate `Related Issues` and `Related PRs` by extracting GitHub issue and
+PR numbers referenced anywhere in the session events (user messages,
+assistant messages, tool outputs, URLs). Use exact numbers only. These
+fields enable deterministic overlap detection during consolidation.

--- a/.config/copilot/skills/daily-summary/SKILL.md
+++ b/.config/copilot/skills/daily-summary/SKILL.md
@@ -22,9 +22,10 @@ sub-agent analysis -> consolidate and merge -> save and present.
 
 ## Input
 
-- `date: string` (optional): Target date in YYYY-MM-DD format. Defaults to today.
+- `date: string` (optional): Target date in YYYY-MM-DD format. Interpreted
+  in the execution environment's local timezone. Defaults to today.
 - `end_date: string` (optional): End date for a range in YYYY-MM-DD format.
-  Defaults to `date` when omitted.
+  Same timezone as `date`. Defaults to `date` when omitted.
 
 ## Output
 
@@ -41,8 +42,13 @@ sub-agent analysis -> consolidate and merge -> save and present.
 
 Resolve the target date from user input. If no date is specified, use today
 in YYYY-MM-DD format (derive from the current datetime provided in the
-conversation context). If the user specifies a date range, set both `date`
-and `end_date`.
+conversation context, adjusted to the execution environment's local timezone).
+If the user specifies a date range, set both `date` and `end_date`.
+
+All dates are interpreted in the execution environment's local timezone.
+Session timestamps (stored in UTC) are converted to local dates before
+comparison. GitHub API queries are expanded to cover the corresponding UTC
+range automatically.
 
 ### Stage 2: Identify Sources
 
@@ -64,6 +70,11 @@ Output is a JSON array of session metadata:
 - `created_at`: ISO 8601 timestamp
 - `summary`: Session summary from workspace.yaml
 - `cwd`: Working directory (repository path)
+- `remote_url`: Git remote origin URL (empty if cwd is deleted or not a
+  git repository)
+- `owner_repo`: Parsed `owner/repo` from remote URL (e.g., `iimuz/dotfiles`).
+  Empty if remote URL is unavailable. Use this field for deterministic
+  repository matching with GitHub activity data.
 
 #### 2b: Identify GitHub Activities
 
@@ -96,6 +107,14 @@ sources are not required.
 
 Create a run directory for intermediate outputs:
 `~/.copilot/session-state/{session_id}/files/{YYYYMMDDHHMMSS}-daily-summary/`
+
+Derive `{YYYYMMDDHHMMSS}` from the `current_datetime` in the conversation
+context. Do not use shell command substitution (e.g., `$(date ...)`) inside
+bash commands to generate timestamps.
+
+Sub-agent task names must be kept under 25 characters to avoid agent ID
+truncation. Use short patterns such as `session-{short_id}` (first 8 chars
+of UUID) and `act-{number}` instead of encoding the full owner/repo/number.
 
 Launch all sub-agents in parallel across both source types.
 
@@ -159,11 +178,14 @@ Generate a consolidated markdown summary following the format defined in
 Key synthesis tasks:
 
 - Group completed items by repository, deduplicating same-task entries.
-- Merge overlapping Copilot sessions and GitHub activities that refer to the
-  same work. Indicators of overlap include: same repository and branch name,
-  PR or issue number referenced in session events, similar task descriptions.
-  When merging, combine the context from both sources to write a richer
-  description than either source alone provides.
+- Merge overlapping Copilot sessions and GitHub activities that refer to
+  the same work. Use a tiered matching strategy: (1) match session
+  `Related Issues`/`Related PRs` fields against activity numbers for
+  high-confidence links, (2) match session `owner_repo` and branch name
+  against activity repository and PR head ref, (3) fall back to text
+  similarity in task descriptions. When merging, combine the context from
+  both sources to write a richer description than either source alone
+  provides.
 - When the same logical task spans multiple repositories, group them
   into a single collective entry.
 - Identify significant decisions across all sessions and activities.

--- a/.config/copilot/skills/daily-summary/SKILL.md
+++ b/.config/copilot/skills/daily-summary/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: daily-summary
 description: >-
-  Use when summarizing daily Copilot session activity into a work report
-  by analyzing session logs for a specified date.
+  Use when summarizing daily work activity into a report by analyzing
+  Copilot session logs and GitHub activity (issues, PRs) for a specified date.
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -11,13 +11,14 @@ disable-model-invocation: false
 
 ## Overview
 
-Generate a qualitative daily work summary from Copilot session logs. A script
-identifies sessions for the target date, sub-agents read each session in full
-and produce per-session summaries, then the results are consolidated into a
-structured daily report.
+Generate a qualitative daily work summary from Copilot session logs and
+GitHub activity (issues, PRs). Scripts identify sessions and GitHub
+activities for the target date, sub-agents analyze each source in parallel,
+then the results are consolidated into a structured daily report that merges
+overlapping items from both sources.
 
-Execution order: determine date -> identify sessions -> parallel sub-agent
-analysis -> consolidate -> save and present.
+Execution order: determine date -> identify sources (parallel) -> parallel
+sub-agent analysis -> consolidate and merge -> save and present.
 
 ## Input
 
@@ -28,6 +29,7 @@ analysis -> consolidate -> save and present.
 ## Output
 
 - Per-session summaries saved to `{run_dir}/session-{uuid}.md`.
+- Per-activity summaries saved to `{run_dir}/activity-{type}-{owner}-{repo}-{number}.md`.
 - Consolidated report saved to `{run_dir}/{date}-daily-summary.md`.
 - The summary content is also presented directly to the user.
 - If the user requests saving to another location, copy the file accordingly.
@@ -42,7 +44,11 @@ in YYYY-MM-DD format (derive from the current datetime provided in the
 conversation context). If the user specifies a date range, set both `date`
 and `end_date`.
 
-### Stage 2: Identify Sessions
+### Stage 2: Identify Sources
+
+Run both scripts in parallel to collect Copilot sessions and GitHub activities.
+
+#### 2a: Identify Sessions
 
 Run [`scripts/extract-sessions.sh`](scripts/extract-sessions.sh) with
 `--date YYYY-MM-DD`. For date ranges, add `--end-date YYYY-MM-DD`.
@@ -59,45 +65,112 @@ Output is a JSON array of session metadata:
 - `summary`: Session summary from workspace.yaml
 - `cwd`: Working directory (repository path)
 
-If the output is an empty array, inform the user that no sessions were found
-for the specified date and stop.
+#### 2b: Identify GitHub Activities
 
-### Stage 3: Parallel Session Analysis
+Run [`scripts/extract-activities.sh`](scripts/extract-activities.sh) with
+`--date YYYY-MM-DD`. For date ranges, add `--end-date YYYY-MM-DD`.
+
+The script queries GitHub via `gh search` to find issues and PRs the user
+was involved with during the target period. Three queries are combined:
+issues involved, PRs involved, and PRs reviewed. Results are deduplicated.
+
+Output is a JSON array of activity metadata:
+
+- `type`: `issue` or `pr`
+- `number`: Issue or PR number
+- `owner`: Repository owner
+- `repo`: Repository name
+- `title`: Issue or PR title
+- `url`: GitHub URL
+- `state`: Current state
+
+#### Handling Empty Results
+
+If both outputs are empty arrays, inform the user that no sessions or
+activities were found for the specified date and stop.
+
+If only one source has results, proceed with that source alone. Both
+sources are not required.
+
+### Stage 3: Parallel Analysis
 
 Create a run directory for intermediate outputs:
 `~/.copilot/session-state/{session_id}/files/{YYYYMMDDHHMMSS}-daily-summary/`
 
-For each session from Stage 2, launch a sub-agent (`task()` with
+Launch all sub-agents in parallel across both source types.
+
+#### 3a: Session Sub-Agents
+
+For each session from Stage 2a, launch a sub-agent (`task()` with
 `agent_type: "daily-summary-session"`) to analyze the session in detail.
-Launch all sub-agents in parallel.
 
 Pass each sub-agent:
 
-- `session_path`: from the Stage 2 output
+- `session_path`: from the Stage 2a output
 - `output_filepath`: `{run_dir}/session-{session_id_being_analyzed}.md`
 
 The agent definition at `.config/copilot/agents/daily-summary-session.md`
 specifies the model, tools, and analysis procedure. Each sub-agent writes
 its summary as a markdown file to the specified output path.
 
-If a sub-agent fails, note the failure and continue with other sessions.
+#### 3b: Activity Sub-Agents
+
+For each activity from Stage 2b, launch a sub-agent (`task()` with
+`agent_type: "daily-summary-activity"`) to analyze the issue or PR in full.
+
+Retrieve the authenticated GitHub username before launching activity
+sub-agents:
+
+```bash
+gh api user --jq .login
+```
+
+Pass each sub-agent:
+
+- `type`: `issue` or `pr`
+- `owner`: Repository owner
+- `repo`: Repository name
+- `number`: Issue or PR number
+- `date`: Start date of the target period
+- `end_date`: End date of the target period
+- `github_user`: Authenticated GitHub username
+- `output_filepath`: `{run_dir}/activity-{type}-{owner}-{repo}-{number}.md`
+
+The agent definition at `.config/copilot/agents/daily-summary-activity.md`
+specifies the model, tools, and analysis procedure. Each sub-agent fetches
+the full issue/PR history, understands the complete context, and produces a
+summary scoped to the user's activity within the target period.
+
+#### Failure Handling
+
+If a sub-agent fails, note the failure and continue with other items.
 Do not retry failed sub-agents.
 
 ### Stage 4: Consolidate
 
-Read all session summary files from the run directory (`{run_dir}/session-*.md`).
+Read all summary files from the run directory:
+
+- Session summaries: `{run_dir}/session-*.md`
+- Activity summaries: `{run_dir}/activity-*.md`
+
 Generate a consolidated markdown summary following the format defined in
 [`references/output-format.md`](references/output-format.md).
 
 Key synthesis tasks:
 
-- Group completed items by repository, deduplicating same-task sessions.
+- Group completed items by repository, deduplicating same-task entries.
+- Merge overlapping Copilot sessions and GitHub activities that refer to the
+  same work. Indicators of overlap include: same repository and branch name,
+  PR or issue number referenced in session events, similar task descriptions.
+  When merging, combine the context from both sources to write a richer
+  description than either source alone provides.
 - When the same logical task spans multiple repositories, group them
   into a single collective entry.
-- Identify significant decisions across all sessions.
+- Identify significant decisions across all sessions and activities.
+- List open items with meaningful activity in the period as in-progress items.
 - Exclude failed or abandoned sessions from completed items (mention
   them separately if relevant).
-- Omit sessions that produced no meaningful outcomes.
+- Omit sessions and activities that produced no meaningful outcomes.
 
 ### Stage 5: Save and Present
 
@@ -110,11 +183,16 @@ to an additional location, copy or write the file to the specified path.
 ## Examples
 
 - Happy: user asks for today's summary, script finds 8 sessions across
-  3 repositories, 8 parallel sub-agents produce session summaries, the
-  consolidated report groups work by repository and lists 5 completed
-  items with 2 decisions.
-- Empty: user asks for a date with no sessions, the script returns an
-  empty array, and the user is informed that no sessions were found.
-- Partial failure: 1 of 8 sub-agents fails to read a corrupted
-  events.jsonl, the remaining 7 summaries are consolidated successfully
-  with a note about the failed session.
+  3 repositories and 5 GitHub activities (3 PRs, 2 issues), 13 parallel
+  sub-agents produce summaries, 2 sessions and PRs overlap and are merged,
+  the consolidated report groups work by repository and lists 7 completed
+  items with 2 in-progress items and 1 decision.
+- Session only: no GitHub activities found (gh not authenticated or no
+  activity), proceeds with Copilot sessions alone. Behaves like the
+  original workflow.
+- Activity only: no Copilot sessions found but GitHub activities exist,
+  proceeds with activities alone.
+- Empty: both sources return empty arrays, the user is informed that no
+  sessions or activities were found.
+- Partial failure: 1 of 13 sub-agents fails, the remaining 12 summaries
+  are consolidated successfully with a note about the failed item.

--- a/.config/copilot/skills/daily-summary/references/output-format.md
+++ b/.config/copilot/skills/daily-summary/references/output-format.md
@@ -1,6 +1,8 @@
 # Output Format
 
-The daily summary follows a fixed markdown structure.
+The daily summary follows a fixed markdown structure. It consolidates both
+Copilot session activity and GitHub activity (issues, PRs) into a unified
+report.
 
 ## Header
 
@@ -11,14 +13,21 @@ Date range: `# YYYY-MM-DD - YYYY-MM-DD 作業サマリー`
 
 ### 完了事項
 
-Synthesize completed work items from session summaries and user messages.
-Group items by repository. Use the repository name as a prefix for each item.
-Focus on outcomes and deliverables, not on individual tool calls or commands.
+Synthesize completed work items from session summaries, activity summaries,
+and user messages. Group items by repository. Use the repository name as a
+prefix for each item. Focus on outcomes and deliverables, not on individual
+tool calls or commands.
 
-Deduplication: When multiple sessions correspond to the same logical task
-(retries, continuations, or iterations), merge them into a single entry.
-Use the session with the most concrete outcome (most files modified or most
-specific summary) as the representative.
+Deduplication: When multiple sessions or activities correspond to the same
+logical task (retries, continuations, or iterations), merge them into a
+single entry. Use the source with the most concrete outcome (most files
+modified, most specific summary, or merged PR) as the representative.
+
+Cross-source merging: When a Copilot session and a GitHub activity (issue
+or PR) refer to the same work, merge them into a single entry. Indicators
+of overlap include: same repository and branch name, PR/issue number
+referenced in session events, similar task descriptions. Prefer the
+description that best captures the outcome.
 
 Cross-repository grouping: When the same logical task was applied across
 multiple repositories (e.g., configuration rollout, dependency update),
@@ -27,6 +36,18 @@ Use a collective description such as "mspf 系 4 リポジトリ: DB deletion
 protection の横展開".
 
 Format: `- repo-name: One-line description of the completed work`
+
+### 進行中の事項
+
+List issues and PRs that remain open at the end of the period and had
+meaningful activity during the period. Include the current status and
+next expected action.
+
+Only include this section if there are open items with activity. Omit
+if all work items were completed or if open items had no meaningful
+activity during the period.
+
+Format: `- repo-name: One-line description (status)`
 
 ### 重要な意思決定
 
@@ -43,6 +64,10 @@ If no significant decisions were identified, omit this section entirely.
 - Focus on what was accomplished, not how it was done.
 - When a session has no summary, infer the purpose from user messages and modified files.
 - Omit sessions that produced no meaningful output (empty summaries, no user messages, no file changes).
+- Omit activities where the user had no direct involvement during the period (only mentioned or subscribed).
+- When merging Copilot session and GitHub activity into one entry, use the
+  combined context to write a richer description than either source alone
+  would provide.
 
 ## Example Output
 
@@ -53,7 +78,12 @@ If no significant decisions were identified, omit this section entirely.
 
 - iimuz/dotfiles: daily-summary skill を作成し、セッションログから日報を自動生成する機能を実装
 - iimuz/dotfiles: Copilot skill の設定ファイル整理、モデル利用状況の監査
-- iimuz/app-backend: 認証 API のレスポンス形式を統一し、エラーハンドリングを改善
+- iimuz/app-backend: 認証 API のレスポンス形式を統一し、エラーハンドリングを改善 (#42 をマージ)
+- iimuz/infra: Terraform state のバックエンド移行 PR を作成しレビュー対応中 (#15)
+
+## 進行中の事項
+
+- iimuz/app-backend: パフォーマンス改善の調査 Issue (#55、次回ベンチマーク実施予定)
 
 ## 重要な意思決定
 

--- a/.config/copilot/skills/daily-summary/scripts/extract-activities.sh
+++ b/.config/copilot/skills/daily-summary/scripts/extract-activities.sh
@@ -4,6 +4,9 @@
 # Identify GitHub activity (issues and PRs) for a specified date range.
 # Outputs a JSON array of activity metadata to stdout.
 # Full issue/PR details are fetched by sub-agents, not this script.
+#
+# Input dates are local timezone. The script converts them to a UTC date
+# range for the GitHub API, expanding by one day to cover timezone boundaries.
 set -euo pipefail
 
 usage() {
@@ -131,7 +134,13 @@ main() {
     exit 1
   fi
 
-  local -r date_range="${date}..${end_date}"
+  # Convert local date boundaries to UTC for the GitHub API.
+  # Start of local start-date in UTC may be the previous day (e.g., JST+9).
+  # End boundary is start of the day AFTER local end-date in UTC.
+  local utc_start utc_end
+  utc_start=$(date -u -d "$date" +%Y-%m-%d)
+  utc_end=$(date -u -d "$end_date + 1 day" +%Y-%m-%d)
+  local -r date_range="${utc_start}..${utc_end}"
 
   local issues_json prs_involves_json prs_reviewed_json
   issues_json=$(search_issues "$date_range" "$limit")

--- a/.config/copilot/skills/daily-summary/scripts/extract-activities.sh
+++ b/.config/copilot/skills/daily-summary/scripts/extract-activities.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Requires: bash 5+, jq, gh (authenticated)
+#
+# Identify GitHub activity (issues and PRs) for a specified date range.
+# Outputs a JSON array of activity metadata to stdout.
+# Full issue/PR details are fetched by sub-agents, not this script.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: extract-activities.sh --date YYYY-MM-DD [--end-date YYYY-MM-DD] [--limit N]
+
+Options:
+  --date      Target date in YYYY-MM-DD format (required)
+  --end-date  End date for range (optional, defaults to --date)
+  --limit     Maximum results per query (optional, defaults to 100)
+EOF
+  exit 1
+}
+
+validate_date() {
+  local -r value="$1" label="$2"
+  if ! [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "Error: $label must be in YYYY-MM-DD format" >&2
+    exit 1
+  fi
+}
+
+search_issues() {
+  local -r date_range="$1" limit="$2"
+  gh search issues \
+    --involves=@me \
+    --updated="$date_range" \
+    --limit "$limit" \
+    --json number,repository,title,url,state \
+    2>/dev/null || echo "[]"
+}
+
+search_prs_involves() {
+  local -r date_range="$1" limit="$2"
+  gh search prs \
+    --involves=@me \
+    --updated="$date_range" \
+    --limit "$limit" \
+    --json number,repository,title,url,state \
+    2>/dev/null || echo "[]"
+}
+
+search_prs_reviewed() {
+  local -r date_range="$1" limit="$2"
+  gh search prs \
+    --reviewed-by=@me \
+    --updated="$date_range" \
+    --limit "$limit" \
+    --json number,repository,title,url,state \
+    2>/dev/null || echo "[]"
+}
+
+normalize_results() {
+  local -r type_value="$1"
+  jq -c --arg type "$type_value" '
+    [.[] | {
+      type: $type,
+      number: .number,
+      owner: (.repository.nameWithOwner | split("/")[0]),
+      repo: (.repository.nameWithOwner | split("/")[1]),
+      title: .title,
+      url: .url,
+      state: .state
+    }]
+  '
+}
+
+deduplicate() {
+  jq -s '
+    add
+    | group_by(.type + ":" + .owner + "/" + .repo + ":#" + (.number | tostring))
+    | map(.[0])
+    | sort_by(.owner + "/" + .repo + ":#" + (.number | tostring))
+  '
+}
+
+main() {
+  local date="" end_date="" limit=100
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --date)
+        [[ $# -ge 2 ]] || usage
+        date="$2"
+        shift 2
+        ;;
+      --end-date)
+        [[ $# -ge 2 ]] || usage
+        end_date="$2"
+        shift 2
+        ;;
+      --limit)
+        [[ $# -ge 2 ]] || usage
+        limit="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: Unknown option: $1" >&2
+        usage
+        ;;
+    esac
+  done
+
+  if [[ -z "$date" ]]; then
+    echo "Error: --date is required" >&2
+    usage
+  fi
+
+  validate_date "$date" "--date"
+  end_date="${end_date:-$date}"
+  validate_date "$end_date" "--end-date"
+
+  if ! type gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required but not found" >&2
+    exit 1
+  fi
+
+  if ! type jq >/dev/null 2>&1; then
+    echo "Error: jq is required but not found" >&2
+    exit 1
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh CLI is not authenticated" >&2
+    exit 1
+  fi
+
+  local -r date_range="${date}..${end_date}"
+
+  local issues_json prs_involves_json prs_reviewed_json
+  issues_json=$(search_issues "$date_range" "$limit")
+  prs_involves_json=$(search_prs_involves "$date_range" "$limit")
+  prs_reviewed_json=$(search_prs_reviewed "$date_range" "$limit")
+
+  local issues_normalized prs_normalized
+  issues_normalized=$(echo "$issues_json" | normalize_results "issue")
+  prs_normalized=$(
+    echo "$prs_involves_json" "$prs_reviewed_json" |
+      jq -s 'add' |
+      normalize_results "pr"
+  )
+
+  echo "$issues_normalized" "$prs_normalized" | deduplicate
+}
+
+main "$@"

--- a/.config/copilot/skills/daily-summary/scripts/extract-sessions.sh
+++ b/.config/copilot/skills/daily-summary/scripts/extract-sessions.sh
@@ -133,7 +133,7 @@ main() {
     remote_url=$(git -C "$cwd" remote get-url origin 2>/dev/null || echo "")
     owner_repo=""
     if [[ -n "$remote_url" ]]; then
-      owner_repo=$(echo "$remote_url" | sed -E 's|.*[:/]([^/]+)/([^/]+?)(\.git)?$|\1/\2|')
+      owner_repo=$(echo "$remote_url" | sed -E 's|.*[:/]([^/]+)/([^/]+)$|\1/\2|; s/\.git$//')
     fi
 
     local result

--- a/.config/copilot/skills/daily-summary/scripts/extract-sessions.sh
+++ b/.config/copilot/skills/daily-summary/scripts/extract-sessions.sh
@@ -4,6 +4,10 @@
 # Identify Copilot sessions for a specified date range.
 # Outputs a JSON array of session paths and workspace metadata to stdout.
 # Does NOT parse events.jsonl; session details are read by sub-agents.
+#
+# Dates are compared in the execution environment's local timezone.
+# The created_at timestamp from workspace.yaml (UTC) is converted to local
+# date before comparison.
 set -euo pipefail
 
 usage() {
@@ -105,7 +109,8 @@ main() {
 
     local ws_created_at
     ws_created_at=$(sed -n 's/^created_at: //p' "$ws")
-    local session_date="${ws_created_at:0:10}"
+    local session_date
+    session_date=$(date -d "$ws_created_at" +%Y-%m-%d 2>/dev/null || echo "${ws_created_at:0:10}")
 
     if [[ "$session_date" < "$date" ]] || [[ "$session_date" > "$end_date" ]]; then
       continue
@@ -124,6 +129,13 @@ main() {
     summary=$(sed -n 's/^summary: //p' "$ws")
     cwd=$(sed -n 's/^cwd: //p' "$ws")
 
+    local remote_url owner_repo
+    remote_url=$(git -C "$cwd" remote get-url origin 2>/dev/null || echo "")
+    owner_repo=""
+    if [[ -n "$remote_url" ]]; then
+      owner_repo=$(echo "$remote_url" | sed -E 's|.*[:/]([^/]+)/([^/]+?)(\.git)?$|\1/\2|')
+    fi
+
     local result
     result=$(jq -nc \
       --arg id "$session_id" \
@@ -131,7 +143,9 @@ main() {
       --arg created_at "$created_at" \
       --arg summary "${summary:-}" \
       --arg cwd "$cwd" \
-      '{session_id: $id, session_path: $path, created_at: $created_at, summary: $summary, cwd: $cwd}')
+      --arg remote_url "$remote_url" \
+      --arg owner_repo "$owner_repo" \
+      '{session_id: $id, session_path: $path, created_at: $created_at, summary: $summary, cwd: $cwd, remote_url: $remote_url, owner_repo: $owner_repo}')
     results+=("$result")
   done
 


### PR DESCRIPTION
## Related URLs

## Changes
- Add extract-activities.sh script to query gh search for issues and PRs via --involves and --reviewed-by
- Add daily-summary-activity agent for per-issue/PR full context analysis
- Extend SKILL.md workflow with parallel source collection (sessions + activities)
- Update output-format.md with cross-source merge guidelines and in-progress section
- Add owner_repo field to extract-sessions.sh via git remote URL lookup
- Add Related Issues/PRs fields to daily-summary-session agent output for structured overlap detection
- Use local timezone for date comparison instead of UTC
- Convert local dates to UTC range in extract-activities.sh for GitHub API queries
- Add timestamp generation and task naming guidance to SKILL.md

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points
- extract-activities.sh の gh search クエリ構成と deduplicate ロジック
- extract-sessions.sh の git remote URL パースと .git suffix 除去
- SKILL.md Stage 4 の tiered merge strategy (structured fields -> repo matching -> text similarity)

## Limitations
- GitHub API の日付フィルタは UTC 基準のため、ローカルタイムゾーン境界付近で余分な結果を含む可能性あり（sub-agent が期間スコープでフィルタ）
- extract-sessions.sh の owner_repo は cwd が削除済みの場合は空文字になる