### PR TITLE
chore: migrate fzf to mise and improve ARM64 setup

### DIFF
--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -3,6 +3,7 @@ aws-vault = "7.2.0"
 awscli = { version = "latest", symlink_bins = "true" }
 cargo-binstall = "latest"
 "cargo:tree-sitter-cli" = "latest"                       # for neovim
+fzf = "0.70.0"
 go = "1"
 lua = "5.1"                                              # neovim luarocksで要求しているバージョンが5.1
 node = "24"

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -5,15 +5,7 @@
     "sessionEnd": [],
     "userPromptSubmitted": [],
     "preToolUse": [],
-    "postToolUse": [
-      {
-        "type": "command",
-        "bash": "mise run format",
-        "powershell": "mise run format",
-        "cwd": ".",
-        "timeoutSec": 30
-      }
-    ],
+    "postToolUse": [],
     "agentStop": [],
     "subagentStop": [],
     "errorOccurred": []

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -138,9 +138,10 @@ fi
 # === github copoilot cli
 if type copilot >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/copilot/agents" "$HOME/.copilot/agents"
-  create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.copilot/skills"
-  create_symlink "$SCRIPT_DIR/.config/copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
   create_symlink "$SCRIPT_DIR/.config/copilot/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"
+  create_symlink "$SCRIPT_DIR/.config/copilot/lsp-config.json" "$HOME/.copilot/lsp-config.json"
+  create_symlink "$SCRIPT_DIR/.config/copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
+  create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.copilot/skills"
 fi
 # === gpg
 if type gpg >/dev/null 2>&1; then
@@ -163,6 +164,9 @@ if ! type starship >/dev/null 2>&1; then curl -sS https://starship.rs/install.sh
 if ! type tailscale >/dev/null 2>&1; then curl -fsSL https://tailscale.com/install.sh | sh; fi
 # === tmux
 if type tmux >/dev/null 2>&1; then
+  if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
+    git clone "https://github.com/tmux-plugins/tpm" "$HOME/.tmux/plugins/tpm"
+  fi
   create_symlink "$SCRIPT_DIR/.tmux.conf" "$HOME/.tmux.conf"
 fi
 # === vifm

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -88,7 +88,6 @@ readonly CONFIG_PATH=$SCRIPT_DIR/.config
 # aptでインストール可能なコマンドはaptでインストールする
 sudo apt-get install -y --no-install-recommends \
   build-essential \
-  fzf \
   gh \
   git-delta \
   jq \


### PR DESCRIPTION
## Related URLs

## Changes
- migrate fzf from apt to mise in ARM64 Linux config
- remove fzf from apt package list in setup_aarch64.sh
- reorder copilot config symlinks for consistency (agents, copilot-instructions, lsp-config, mcp-config, skills)
- add lsp-config.json symlink to copilot setup section
- add conditional clone of tmux plugin manager (tpm) before creating tmux symlink
- remove postToolUse hook that ran mise run format automatically

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->