### PR TITLE
feat: add devcontainer configuration with SSH support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Default",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "extensions": "dlvhdr/gh-dash"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers-extra/features/apt-get-packages:1": {
+      // - libclang-dev: mise で tree sitter cli の cargo install で必要
+      // - libreadline-dev: mise で lua をインストールするために必要
+      "packages": "git-delta,libclang-dev,libreadline-dev,ripgrep,vifm"
+    },
+    "ghcr.io/devcontainers-extra/features/fzf:1": {},
+    "ghcr.io/devcontainers-extra/features/starship:1": {},
+    "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+      // jq, yq をインストール
+      "yqVersion": "4"
+    },
+    "ghcr.io/GeorgOfenbeck/features/lazygit-linuxbinary:1": {},
+    "ghcr.io/roul/devcontainer-features/mise:1": {},
+    "ghcr.io/stu-bell/devcontainer-features/neovim:0": {}
+  },
+  "remoteUser": "vscode",
+  "remoteEnv": {
+    "FFGHQ_MAXDEPTH": "1",
+    "FFGHQ_MINDEPTH": "1",
+    "SOURCE_ROOT": "/workspaces"
+  },
+  "postCreateCommand": "bash .devcontainer/post-install.sh"
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -22,12 +22,7 @@ function err() {
   exit 1
 }
 
-function cleanup() {
-  echo "cleanup completed" >/dev/null
-}
-
 trap 'err ${LINENO} "$BASH_COMMAND"' ERR
-trap cleanup EXIT
 
 function usage() {
   cat <<EOF

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_name=$(basename "${0}")
+readonly script_name
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+
+function log_info() {
+  local _message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [INFO] $_message" >&2
+}
+
+function log_err() {
+  local _message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [ERROR] $_message" >&2
+}
+
+function err() {
+  log_err "Line $1: $2" >&2
+  exit 1
+}
+
+function cleanup() {
+  echo "cleanup completed" >/dev/null
+}
+
+trap 'err ${LINENO} "$BASH_COMMAND"' ERR
+trap cleanup EXIT
+
+function usage() {
+  cat <<EOF
+Usage: ${script_name} [OPTIONS]
+
+Post-installation script for devcontainer setup.
+Configures dotfiles and Neovim plugins.
+
+OPTIONS:
+  -h, --help      Show this help message
+  -v, --verbose   Enable verbose output
+
+EXAMPLE:
+  # Run post-installation setup
+  $ ${script_name}
+EOF
+}
+
+function setup_dotfiles() {
+  log_info "Setting up dotfiles..."
+
+  local -r repo_root="$(cd "$script_dir/.." && pwd)"
+
+  (
+    cd "$repo_root"
+    mise trust
+    bash setup_codespaces.sh
+  )
+  (
+    # npm, uv 等の依存があるため 2 回実行が必要
+    # (1 回目で npm/uv をインストールし、2 回目でそれらに依存するツールをインストール)
+    cd
+    mise trust
+    mise install
+    mise install
+  )
+}
+
+function setup_nvim() {
+  log_info "Setting up Neovim..."
+
+  # Neovim plugin installation may fail in devcontainer provisioning (e.g., network
+  # issues, missing dependencies). These failures are non-fatal.
+  nvim --headless "+Lazy! sync" +qa || true
+  nvim --headless "+MasonToolsInstallSync" +qa || true
+  nvim --headless "+TSUpdateSync" +qa || true
+}
+
+function main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -v | --verbose)
+        set -x
+        shift
+        ;;
+      *)
+        log_err "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+
+  mise trust
+  setup_dotfiles
+  setup_nvim
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/instructions/devcontainer.instructions.md
+++ b/.github/instructions/devcontainer.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: ".devcontainer/**"
+---
+
+# Devcontainer Configuration
+
+## Official Documentation
+
+When creating or modifying devcontainer files, use a subagent to fetch
+the latest specification from the official documentation and return the
+relevant specification details:
+
+- [Dev Container Specification](https://containers.dev/implementors/json_reference/)
+- [Available Features](https://containers.dev/features)
+
+If the fetch fails, follow the project policy below instead.
+
+## Project Policy
+
+The following rules are project-specific policies.
+
+- Use JSONC (JSON with Comments) for `devcontainer.json`.

--- a/setup_codespaces.sh
+++ b/setup_codespaces.sh
@@ -64,9 +64,9 @@ if type git >/dev/null 2>&1; then
 fi
 # === github copilot cli
 if type copilot >/dev/null 2>&1; then
-  create_symlink "$SCRIPT_DIR/.config/copilot/agents" "$HOME/.config/.copilot/agents"
-  create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.config/.copilot/skills"
-  create_symlink "$SCRIPT_DIR/.config/copilot/mcp-config.json" "$HOME/.config/.copilot/mcp-config.json"
+  create_symlink "$SCRIPT_DIR/.config/copilot/agents" "$HOME/.copilot/agents"
+  create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.copilot/skills"
+  create_symlink "$SCRIPT_DIR/.config/copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
 fi
 # === lazygit
 if type lazygit >/dev/null 2>&1; then


### PR DESCRIPTION
## Related URLs
- Closes #160
- Related: #165 (Neovim setup failure)
- Related: #166 (Dotfiles double install)

## Changes
- Add .devcontainer/devcontainer.json with ubuntu-24.04 base image and features (sshd, common-utils, copilot-cli, github-cli, fzf, starship, tmux, lazygit, mise, neovim)
- Add .devcontainer/post-install.sh for dotfiles setup, mise install, and Neovim plugin bootstrap
- Add .github/instructions/devcontainer.instructions.md with devcontainer conventions
- Fix copilot symlink destination in setup_codespaces.sh from $HOME/.config/.copilot/ to $HOME/.copilot/

## Confirmation Results
- Lint and format passed (mise run lint, mise run format)
- Actual devcontainer execution log analyzed (docs/reports/2026-04-04-devcontainer-log.md)

## Review Points
- Neovim setup commands fail on first boot (#165); currently suppressed with || true
- Codespaces dotfiles auto-install conflicts with postCreateCommand (#166)

## Limitations
- Neovim plugins are not installed during post-install (tracked in #165)
- Dotfiles double installation shows error in creation log (tracked in #166)