### PR TITLE
fix: fix Renovate no-repositories error and address warnings

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
@@ -30,3 +30,4 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: ${{ inputs.log_level || 'info' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", "helpers:pinGitHubActionDigests"],
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "dependencyDashboard": true,
   "minimumReleaseAge": "14 days",
   "labels": ["dependencies"],


### PR DESCRIPTION
## Related URLs
- https://github.com/iimuz/dotfiles/actions/runs/23976081700

## Changes
- add RENOVATE_REPOSITORIES env var to tell Renovate which repo to scan
- set gitAuthor in renovate.json to avoid Mend-owned default email warning
- upgrade actions/checkout from v4.2.2 to v6.0.2 to resolve Node.js 20 deprecation

## Confirmation Results
- analyzed workflow run logs from actions/runs/23976081700
- identified root cause: missing RENOVATE_REPOSITORIES caused 'No repositories found' error
- lint and format pass

## Review Points
- gitAuthor email choice (bot@renovateapp.com)

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->