### PR TITLE
fix: add mise platform config detection and raise PR hourly limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   "dependencyDashboard": true,
   "minimumReleaseAge": "14 days",
   "labels": ["dependencies"],
+  "mise": {
+    "fileMatch": ["\\.config/mise/config-.+\\.toml$"]
+  },
   "packageRules": [
     {
       "description": "Constrain lua to 5.1.x for neovim compatibility",

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "dependencyDashboard": true,
   "minimumReleaseAge": "14 days",
+  "prHourlyLimit": 5,
   "labels": ["dependencies"],
   "mise": {
     "fileMatch": ["\\.config/mise/config-.+\\.toml$"]


### PR DESCRIPTION
## Related URLs
- https://github.com/iimuz/dotfiles/issues/170
- https://github.com/iimuz/dotfiles/actions/runs/23977364551

## Changes
- add fileMatch regex to detect .config/mise/config-{mac,linux,codespaces}.toml
- raise prHourlyLimit from default 2 to 5 to reduce rate-limited PRs

## Confirmation Results
- lint and format pass
- verified default mise fileMatch patterns exclude hyphen-separated config names
- confirmed prHourlyLimit: 2 caused rate-limiting via debug logs

## Review Points
- fileMatch regex pattern correctness
- prHourlyLimit value (5 vs other values)

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->