### PR TITLE
fix: use matchDepNames for Renovate version constraints

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,14 +7,20 @@
   "prHourlyLimit": 5,
   "labels": ["dependencies"],
   "mise": {
-    "managerFilePatterns": ["/\.config/mise/config-.+\.toml$/"]
+    "managerFilePatterns": ["/\\.config/mise/config-.+\\.toml$/"]
   },
   "packageRules": [
     {
       "description": "Constrain lua to 5.1.x for neovim compatibility",
       "matchManagers": ["mise"],
-      "matchPackageNames": ["lua"],
-      "allowedVersions": "/^5\.1\./"
+      "matchDepNames": ["lua"],
+      "allowedVersions": "/^5\\.1\\./"
+    },
+    {
+      "description": "Constrain python to 3.13.x",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["python"],
+      "allowedVersions": "/^3\\.13\\./"
     },
     {
       "description": "Group all mise major updates into a single PR",


### PR DESCRIPTION
## Changes

- `matchPackageNames` -> `matchDepNames` for lua constraint
- Add python 3.13.x version constraint (`matchDepNames`)
- Fix JSON escaping in `managerFilePatterns` and `allowedVersions`

## Root Cause

Renovate's `matchPackageNames` only matches the `packageName` field (e.g., `lua/lua`, `python/cpython`), NOT the `depName` field (e.g., `lua`, `python`).

Source: [`lib/util/package-rules/package-names.ts`](https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/package-names.ts) - the matcher destructures only `{ packageName }`.

For the mise manager, lua's `depName` is `lua` but `packageName` is `lua/lua` (from [asdf upgradeable-tooling](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/asdf/upgradeable-tooling.ts)). The glob pattern `lua` didn't match `lua/lua`, so the `allowedVersions` constraint was silently ignored.

## Verification

After merging and the next Renovate run:
- PR #174 should be rebased WITHOUT lua and python updates
- Dependency Dashboard should show lua and python as constrained