### PR TITLE
chore: remove python version constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,12 +17,6 @@
       "allowedVersions": "/^5\\.1\\./"
     },
     {
-      "description": "Constrain python to 3.13.x",
-      "matchManagers": ["mise"],
-      "matchDepNames": ["python"],
-      "allowedVersions": "/^3\\.13\\./"
-    },
-    {
       "description": "Group all mise major updates into a single PR",
       "matchManagers": ["mise"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
## Changes

Remove the `allowedVersions: /^3\.13\./` constraint for python.

Python 3.14 has been stable since October 2025. Allowing Renovate to update python to the latest stable version.