### PR TITLE
fix: fix mise install failures for lua and python

### DIFF
--- a/.config/mise/config-codespaces.toml
+++ b/.config/mise/config-codespaces.toml
@@ -17,6 +17,9 @@ shellcheck = "0.11.0"
 shfmt = "3.13.0"
 uv = "0.11.3"
 
+[env]
+ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)
+
 [settings]
 experimental = true
 

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -24,6 +24,7 @@ shfmt = "3.13.0"
 uv = "0.11.3"
 
 [env]
+ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)
 # UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
 
 [settings]

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -14,7 +14,6 @@ node = "24.14.1"
 "npm:neovim" = "5.4.0"                                    # for neovim
 "pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"
 "pipx:markitdown-mcp" = { version = "0.0.1a4", all = "" } # for copilot
-"pipx:oraios/serena" = "0.9.1"                            # for copilot
 "pipx:pynvim" = "0.6.0"                                   # for neovim
 pnpm = "10.33.0"
 python = "3.14.3"

--- a/.config/mise/config-mac.toml
+++ b/.config/mise/config-mac.toml
@@ -20,7 +20,6 @@ node = "24.14.0"
 "npm:mcp-remote" = "0.1.38"                             # for copilot
 "npm:neovim" = "5.4.0"                                  # for neovim
 "pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"
-"pipx:oraios/serena" = "0.9.1"                          # for copilot
 "pipx:pynvim" = "0.6.0"                                 # for neovim
 pnpm = "10.33.0"
 python = "3.14.3"

--- a/.config/mise/config-mac.toml
+++ b/.config/mise/config-mac.toml
@@ -32,6 +32,7 @@ uv = "0.11.3"
 yq = "4.52.5"
 
 [env]
+ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)
 # UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
 
 [settings]

--- a/.config/raycast/scripts/startup-mac.sh
+++ b/.config/raycast/scripts/startup-mac.sh
@@ -12,36 +12,17 @@
 set -Eeuo pipefail
 
 # brew
-# x86_64 archの方を呼び出す方法がわからない。
 brew update
 brew upgrade
 brew bundle --file ../../homebrew/Brewfile cleanup --force
-# 自動でアップロードする機能をもつパッケージについてもhomebrewでアップデートできる。
-# ただし、homebrewの思想として自前でアップデート機能を持つものは自分で実施なので、基本は有効にしない。
-# ref: <https://qiita.com/bonji/items/183160eab52919aaf93e>
-# brew upgrade --cask --greedy
-mise up
+
+# update mise
+mise self-update -y
+mise prune -y
+mise cache clean -y
 mise exec -- gh extension upgrade --all
 
-# open -a "Scroll Reverser" # マウスによるscrollの逆転
-
-# password and vpn
-# open -a Bitwarden # bitwardenの起動設定で対処
+# Open tools
 open -a "Cisco Secure Client"
-
-# browser
-# open -a "Google Chrome"
-open -a "Microsoft Edge"
-# open -a "Brave browser"
-# open -a "firefox"
-
-# communication tool
-# open -a "Slack"
-# open -a "OneDrive"
-# open -a "Microsoft Teams"
-# open -a "Microsoft Outlook"
-
-# work tools
 open -a "Ghostty"
-# open -a "Visual Studio Code"
-# open -a "Rancher Desktop"
+open -a "Microsoft Edge"

--- a/update_aarch64.sh
+++ b/update_aarch64.sh
@@ -16,7 +16,6 @@ fi
 
 if type mise >/dev/null 2>&1; then
   mise self-update -y
-  mise up
   mise prune -y
   mise cache clean -y
 fi


### PR DESCRIPTION
## Related URLs

## Changes
- Pin ASDF_LUA_LUAROCKS_VERSION=3.12.2 to avoid corrupted luarocks 3.13.0 rockspec (luarocks/luarocks#1851)
- Remove pipx:oraios/serena (upstream tag 0.9.1 deleted)
- Simplify startup-mac.sh and add mise self-update/prune/cache clean
- Remove mise up from update_aarch64.sh

## Confirmation Results
- Verified lua@5.1.5 installs successfully with luarocks 3.12.2
- Verified python@3.14.3 installs successfully after mise self-update to 2026.4.3

## Review Points
- luarocks pin is a temporary workaround until upstream fixes 3.13.0 tarball

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->