### PR TITLE
chore: add mise install step to aarch64 update script

### DIFF
--- a/update_aarch64.sh
+++ b/update_aarch64.sh
@@ -16,6 +16,7 @@ fi
 
 if type mise >/dev/null 2>&1; then
   mise self-update -y
+  mise install
   mise prune -y
   mise cache clean -y
 fi


### PR DESCRIPTION
## Related URLs

## Changes
- add `mise install` call after `mise self-update` to ensure all configured tools are installed on update

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->