### PR TITLE
feat: add intake-analyst and runner agents for copilot workflow

### DIFF
--- a/.config/copilot/agents/code-review-best-practices.md
+++ b/.config/copilot/agents/code-review-best-practices.md
@@ -12,7 +12,11 @@ tools: ["read", "search", "edit"]
 
 Read the change target (diff or file list) and analyze for coding standards and
 convention issues. Keep findings strictly within best-practices scope.
-Write the review to `output_filepath`.
+
+Write findings to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include findings in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (3 findings)").
+If there are no findings, still create the file with an empty review body.
 
 Abort if findings drift outside best-practices scope.
 Abort if the output file already exists.
@@ -40,7 +44,7 @@ causes correctness issues.
 
 ## Output
 
-Written to `output_filepath`. Organize findings by severity.
+Write findings to `output_filepath` using a file-writing tool call. Organize findings by severity.
 Omit severity sections with no findings.
 
 ```markdown

--- a/.config/copilot/agents/code-review-consolidate.md
+++ b/.config/copilot/agents/code-review-consolidate.md
@@ -13,7 +13,11 @@ tools: ["read", "search", "edit"]
 
 Read `review_file_paths`, `gap_list_path`, and `crosscheck_paths`.
 Deduplicate findings, apply cross-check assessments, and synthesize a unified
-report. Write the result to `output_filepath`.
+report.
+
+Write the consolidated report to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include the report in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (5 findings)").
 
 Abort if review input files are missing.
 Abort if the consolidated report shape is invalid.
@@ -79,7 +83,7 @@ Abort if the consolidated report shape is invalid.
 
 ## Output
 
-Written to `output_filepath`.
+Write findings to `output_filepath` using a file-writing tool call.
 
 ```markdown
 ## Code Review Summary

--- a/.config/copilot/agents/code-review-cross-check.md
+++ b/.config/copilot/agents/code-review-cross-check.md
@@ -12,7 +12,10 @@ tools: ["read", "search", "edit"]
 
 Read the provided `concerns` list for the given `aspect`, verify each concern
 against the code evidence, and assess each as VALID, INVALID, or UNCERTAIN.
-Write the results to `output_filepath`.
+
+Write results to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include assessment results in the response text.
+Return only: file path and assessment count (e.g., "Written to /path/to/file.md (2 valid, 1 invalid, 0 uncertain)").
 
 Scope is limited to the provided concerns and their specified locations only.
 Do not perform a full review -- only verify the listed concerns.
@@ -59,7 +62,7 @@ Abort if the output file already exists.
 
 ## Output
 
-Written to `output_filepath`. Organize results by assessment.
+Write results to `output_filepath` using a file-writing tool call. Organize results by assessment.
 Omit assessment sections with no entries.
 
 ```markdown

--- a/.config/copilot/agents/code-review-design-compliance.md
+++ b/.config/copilot/agents/code-review-design-compliance.md
@@ -12,7 +12,11 @@ tools: ["read", "search", "edit"]
 
 Read the change target (diff or file list) and analyze code changes against design
 reference criteria. Keep findings scoped to design alignment.
-Write the review to `output_filepath`.
+
+Write findings to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include findings in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (3 findings)").
+If there are no findings, still create the file with an empty review body.
 
 Abort if `design_info` is missing or empty.
 Abort if the output file already exists.
@@ -37,7 +41,7 @@ MEDIUM. Naming inconsistencies default to LOW.
 
 ## Output
 
-Written to `output_filepath`. Organize findings by severity.
+Write findings to `output_filepath` using a file-writing tool call. Organize findings by severity.
 Omit severity sections with no findings.
 
 ```markdown

--- a/.config/copilot/agents/code-review-gap-analysis.md
+++ b/.config/copilot/agents/code-review-gap-analysis.md
@@ -13,7 +13,10 @@ tools: ["read", "search", "edit"]
 
 Read `review_file_paths` and compare findings across reviewers to identify gaps
 where one reviewer found a concern that others missed.
-Write the gap list to `output_filepath`.
+
+Write the gap list to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include the gap list in the response text.
+Return exactly one response line: `gaps_found: {N}`.
 
 If a review file cannot be parsed, skip that model for the affected aspect and continue.
 Compare findings only within the same aspect. Keep concern text to a single line.
@@ -59,7 +62,7 @@ finding at that location or about that condition.
 
 ## Output
 
-Written to `output_filepath`. Format:
+Write the gap list to `output_filepath` using a file-writing tool call. Format:
 
 ```yaml
 gaps_found: N

--- a/.config/copilot/agents/code-review-performance.md
+++ b/.config/copilot/agents/code-review-performance.md
@@ -12,7 +12,11 @@ tools: ["read", "search", "edit"]
 
 Read the change target (diff or file list) and analyze for performance and efficiency
 issues. Keep findings strictly within performance scope.
-Write the review to `output_filepath`.
+
+Write findings to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include findings in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (3 findings)").
+If there are no findings, still create the file with an empty review body.
 
 Abort if findings drift outside performance scope.
 Abort if the output file already exists.
@@ -37,7 +41,7 @@ CRITICAL only when the issue causes timeouts, OOM, or denial-of-service conditio
 
 ## Output
 
-Written to `output_filepath`. Organize findings by severity.
+Write findings to `output_filepath` using a file-writing tool call. Organize findings by severity.
 Omit severity sections with no findings.
 
 ```markdown

--- a/.config/copilot/agents/code-review-quality.md
+++ b/.config/copilot/agents/code-review-quality.md
@@ -12,7 +12,11 @@ tools: ["read", "search", "edit"]
 
 Read the change target (diff or file list) and analyze for readability, maintainability,
 and error-handling quality issues. Keep findings strictly within quality scope.
-Write the review to `output_filepath`.
+
+Write findings to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include findings in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (3 findings)").
+If there are no findings, still create the file with an empty review body.
 
 Abort if findings drift outside quality scope.
 Abort if the output file already exists.
@@ -37,7 +41,7 @@ silently drops data). Use LOW for minor style-adjacent quality observations.
 
 ## Output
 
-Written to `output_filepath`. Organize findings by severity.
+Write findings to `output_filepath` using a file-writing tool call. Organize findings by severity.
 Omit severity sections with no findings.
 
 ```markdown

--- a/.config/copilot/agents/code-review-security.md
+++ b/.config/copilot/agents/code-review-security.md
@@ -12,7 +12,11 @@ tools: ["read", "search", "edit"]
 
 Read the change target (diff or file list) and analyze for security vulnerabilities
 and exploitability issues. Keep findings strictly within security scope.
-Write the review to `output_filepath`.
+
+Write findings to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include findings in the response text.
+Return only: file path and finding count (e.g., "Written to /path/to/file.md (3 findings)").
+If there are no findings, still create the file with an empty review body.
 
 Abort if findings drift outside security scope.
 Abort if the output file already exists.
@@ -39,7 +43,7 @@ informational security observations.
 
 ## Output
 
-Written to `output_filepath`. Organize findings by severity.
+Write findings to `output_filepath` using a file-writing tool call. Organize findings by severity.
 Omit severity sections with no findings.
 
 ```markdown

--- a/.config/copilot/agents/code-review-triage.md
+++ b/.config/copilot/agents/code-review-triage.md
@@ -12,9 +12,13 @@ tools: ["read", "search", "edit"]
 ## Overview
 
 Read `consolidated_report_path` and the source code of files listed in finding
-`File:` references. Classify each finding into one of two tiers and write the
-triage report to `output_filepath`. Pass `target` through to resolve the changed
-file set when needed for context.
+`File:` references. Classify each finding into one of two tiers.
+
+Write the triage report to a new file at the exact path given in `output_filepath` using a file-writing tool call.
+Do not include the report in the response text.
+Return only: file path and tier counts (e.g., "Written to /path/to/file.md (2 recommended, 3 consider)").
+
+Pass `target` through to resolve the changed file set when needed for context.
 
 Abort if `consolidated_report_path` is missing or unreadable.
 Abort if the output file already exists.
@@ -112,7 +116,7 @@ If validation fails, abort with an error message describing the discrepancy.
 
 ## Output
 
-Written to `output_filepath`.
+Write the triage report to `output_filepath` using a file-writing tool call.
 
 ```markdown
 ## Code Review Triage Report

--- a/.config/copilot/agents/gh-issue-comment-runner.md
+++ b/.config/copilot/agents/gh-issue-comment-runner.md
@@ -1,0 +1,26 @@
+---
+name: gh-issue-comment-runner
+description: Must be used for all GitHub Issue comment operations.
+model: claude-sonnet-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["skill", "execute", "read", "search"]
+---
+
+# Issue Comment Runner
+
+Invoke `skill(gh-issue-comment)` and return a minimal summary to the caller.
+
+## Process
+
+1. Pass through all caller-provided parameters to `skill(gh-issue-comment)`.
+2. Capture the comment URL.
+
+## Output Format
+
+Return only:
+
+- Success or failure status.
+- Comment URL.
+
+Do not return the full comment body or intermediate reasoning.

--- a/.config/copilot/agents/gh-issue-create-runner.md
+++ b/.config/copilot/agents/gh-issue-create-runner.md
@@ -1,0 +1,26 @@
+---
+name: gh-issue-create-runner
+description: Must be used for all GitHub Issue creation operations.
+model: claude-sonnet-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["skill", "execute", "read", "search"]
+---
+
+# Issue Create Runner
+
+Invoke `skill(gh-issue-create)` and return a minimal summary to the caller.
+
+## Process
+
+1. Pass through all caller-provided parameters to `skill(gh-issue-create)`.
+2. Capture the issue number and URL.
+
+## Output Format
+
+Return only:
+
+- Success or failure status.
+- Issue number and URL.
+
+Do not return the full issue body or intermediate reasoning.

--- a/.config/copilot/agents/gh-pr-create-runner.md
+++ b/.config/copilot/agents/gh-pr-create-runner.md
@@ -1,0 +1,26 @@
+---
+name: gh-pr-create-runner
+description: Must be used for all GitHub pull request creation operations.
+model: claude-sonnet-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["skill", "execute", "read", "search"]
+---
+
+# PR Create Runner
+
+Invoke `skill(gh-pr-create)` and return a minimal summary to the caller.
+
+## Process
+
+1. Pass through all caller-provided parameters to `skill(gh-pr-create)`.
+2. Capture the PR number and URL.
+
+## Output Format
+
+Return only:
+
+- Success or failure status.
+- PR number and URL.
+
+Do not return the full PR body, diff, or intermediate reasoning.

--- a/.config/copilot/agents/git-commit-runner.md
+++ b/.config/copilot/agents/git-commit-runner.md
@@ -1,0 +1,27 @@
+---
+name: git-commit-runner
+description: Must be used for all git commit operations.
+model: claude-sonnet-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["skill", "execute", "read", "search"]
+---
+
+# Git Commit Runner
+
+Invoke `skill(git-commit)` and return a minimal summary to the caller.
+
+## Process
+
+1. Invoke `skill(git-commit)`.
+2. Capture the commit SHA and message.
+
+## Output Format
+
+Return only:
+
+- Success or failure status.
+- Commit SHA (short hash).
+- One-line commit message.
+
+Do not return diff contents, staging details, or intermediate reasoning.

--- a/.config/copilot/agents/intake-analyst.md
+++ b/.config/copilot/agents/intake-analyst.md
@@ -1,0 +1,57 @@
+---
+name: intake-analyst
+description: Must be used before the main agent reads files or searches the codebase for any user request. Returns a structured summary of intent, relevant code, and recommended actions.
+model: claude-opus-4.6
+user-invocable: false
+disable-model-invocation: false
+tools: ["read", "search"]
+---
+
+# Intake Analyst
+
+Analyze user requests and codebase context to produce a concise summary for the main agent.
+Do not modify code. Do not execute commands. Report findings as structured text only.
+
+## Process
+
+1. Parse the user request to identify intent, constraints, and implicit assumptions.
+2. Search the codebase for files, symbols, and patterns relevant to the request.
+3. Read identified files to understand current state and constraints.
+4. Assess scope: what changes are needed, what is out of scope, and what risks exist.
+5. Return a structured summary to the caller.
+
+## Boundaries
+
+- Do not modify files.
+- Do not execute shell commands.
+- Do not fetch external resources.
+- Do not make design decisions. Present options with trade-offs for the caller to decide.
+- Stop investigating when sufficient context is gathered. Do not chase every lead.
+
+## Output Format
+
+Structure every response with these four sections:
+
+### Request Summary
+
+What the user wants in 1-2 sentences. Include inferred intent when the request is ambiguous.
+
+### Relevant Files
+
+List files and line ranges relevant to the request. Use `path:start-end` format.
+Include only sections the caller needs to read. Do not list entire files.
+
+Example:
+
+- `.config/copilot/agents/triage-expert.md:1-8` - frontmatter pattern reference
+- `.github/instructions/custom-agents.instructions.md:19-28` - sub-agent policy
+
+### Recommended Actions
+
+Concrete next steps for the caller. Be specific: name files to create or modify,
+patterns to follow, and commands to run.
+
+### Scope Boundaries
+
+What is in scope and what is out of scope for this request.
+Flag risks or dependencies that the caller should consider before proceeding.

--- a/.config/copilot/agents/intake-analyst.md
+++ b/.config/copilot/agents/intake-analyst.md
@@ -4,7 +4,18 @@ description: Must be used before the main agent reads files or searches the code
 model: claude-opus-4.6
 user-invocable: false
 disable-model-invocation: false
-tools: ["read", "search"]
+tools:
+  [
+    "read",
+    "search",
+    "bash",
+    "atlassian/getJiraIssue",
+    "atlassian/searchJiraIssuesUsingJql",
+    "atlassian/getJiraIssueRemoteIssueLinks",
+    "atlassian/getConfluencePage",
+    "atlassian/searchConfluenceUsingCql",
+    "atlassian/getConfluencePageDescendants",
+  ]
 ---
 
 # Intake Analyst
@@ -23,8 +34,14 @@ Do not modify code. Do not execute commands. Report findings as structured text 
 ## Boundaries
 
 - Do not modify files.
-- Do not execute shell commands.
-- Do not fetch external resources.
+- Shell commands are restricted to readonly GitHub CLI operations only.
+  Allowed: `gh issue view`, `gh issue list`, `gh issue status`,
+  `gh pr view`, `gh pr list`, `gh pr status`, `gh pr diff`,
+  `gh pr checks`.
+  Prohibited: all write operations (create, edit, close, merge, comment, delete, etc.).
+- Atlassian tools are restricted to readonly operations only.
+  Do not call addComment, transitions, or any mutating operations.
+- External access is limited to GitHub CLI and Atlassian MCP tools listed in the tools field.
 - Do not make design decisions. Present options with trade-offs for the caller to decide.
 - Stop investigating when sufficient context is gathered. Do not chase every lead.
 

--- a/.config/copilot/agents/orchestrator.md
+++ b/.config/copilot/agents/orchestrator.md
@@ -14,6 +14,8 @@ tools:
     "list_agents",
     "read_agent",
     "fetch_copilot_cli_documentation",
+    "read",
+    "edit",
   ]
 ---
 
@@ -44,12 +46,15 @@ Principles:
 | `store_memory`                    | Persist synthesized facts about the codebase    |
 | `list_agents` / `read_agent`      | Monitor background agents                       |
 | `fetch_copilot_cli_documentation` | Answer questions about Copilot CLI capabilities |
+| `read`                            | Read planning file and session files            |
+| `edit`                            | Update planning file and session files          |
 
 ## Process
 
 1. Interpret user input. If only the user can resolve the ambiguity (not investigation), use `ask_user`.
-2. Dispatch a planning subagent (`general-purpose`) to analyze the request and return a structured task breakdown.
-3. Based on the breakdown, insert subtasks into `sql` todos table.
+2. Dispatch `intake-analyst` to analyze the request and return a structured summary
+   of intent, relevant code, and recommended actions.
+3. Based on the summary, insert subtasks into `sql` todos table.
 4. Dispatch execution subagents in parallel when tasks are independent.
 5. Chain dependent tasks sequentially using previous results.
 6. If subagent output does not obviously match the user's stated goal, dispatch
@@ -91,10 +96,12 @@ decomposition, or planning, use `general-purpose`.
 
 ### Model
 
-| Model             | Best For                                                 |
-| :---------------- | :------------------------------------------------------- |
-| `claude-opus-4.6` | Nuanced reasoning, code review, complex refactoring      |
-| `gpt-5.4`         | Code generation, structured output, tool-heavy workflows |
+| Model                                    | Best For                                             |
+| :--------------------------------------- | :--------------------------------------------------- |
+| `claude-opus-4.7` (fallback: `opus-4.6`) | Default. Nuanced reasoning, review, complex refactor |
+| `claude-sonnet-4.6`                      | Mechanical ops: git, file writes, template expansion |
+| `claude-haiku-4.5`                       | Trivial ops: single commands, simple file reads      |
+| `gpt-5.4`                                | Alternative perspective, second opinions             |
 
 Prefer consistency: keep the same model within a multi-step subtask.
 
@@ -107,8 +114,9 @@ When a skill is available and relevant:
 
 ## Anti-Patterns
 
+- NEVER use `read` or `edit` on codebase files. Use them ONLY for the user-specified planning file and session files.
 - NEVER call data-fetching tools (bash, view, grep, GitHub MCP, web) directly.
-- NEVER implement or edit files directly.
+- NEVER implement or edit codebase files directly.
 - NEVER prompt subagents for options or recommendations that the orchestrator then
   selects from—include the decision in the subagent's execution scope.
 - NEVER judge subagent output quality or correctness yourself—when verification is needed, dispatch a verification subagent.

--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -22,6 +22,7 @@
 - Limit main context intake to ~200 lines per turn. Use view_range or
   delegate summarization when an artifact exceeds this.
 - When facing a decision, delegate analysis first. Main reviews and decides.
+- On every new user request, delegate to intake-analyst first.
 - ALWAYS execute independent subagent workflows in parallel.
 - ALWAYS escalate conflicts, ambiguity, or insufficient evidence to the user.
 - These rules override any conflicting built-in tool guidance.

--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -22,7 +22,6 @@
 - Limit main context intake to ~200 lines per turn. Use view_range or
   delegate summarization when an artifact exceeds this.
 - When facing a decision, delegate analysis first. Main reviews and decides.
-- On every new user request, delegate to intake-analyst first.
 - When a runner agent exists for an operation (git-commit, gh-issue, gh-pr),
   use the runner agent. Do not invoke the corresponding skill directly.
 - ALWAYS execute independent subagent workflows in parallel.

--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -62,7 +62,9 @@
 
 ### Task Completion Protocol
 
-- ALWAYS call ask_user (allow_freeform: true) as the final action when completing a user request, regardless of task size.
+- ALWAYS call ask_user (allow_freeform: true) at the end of every response to the user.
+  The task is complete only when the user explicitly confirms completion.
+- At the start of every task, add a final TODO: "call ask_user to confirm completion with the user."
 
 ## Style and Preferences
 

--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -13,21 +13,18 @@
 ### Subagent Strategy and Parallel Execution
 
 - The main agent handles coordination, user interaction, and decisions only.
-  Delegate all other work (investigation, analysis, planning, execution) to
-  subagents. Subagents consume ~400 tokens of main context (prompt + summary)
-  while direct multi-step operations consume 1000-5000 tokens.
-- A single tool call with an immediately actionable result (e.g., confirming
-  a file exists) is the only permitted exception to delegation.
-  Two or more sequential calls constitute a work phase and must be delegated.
-- When facing a decision, delegate the analysis to a subagent first: have it
-  investigate the codebase, evaluate options, and return a structured
-  recommendation. The main agent reviews the recommendation and decides.
-- ALWAYS use view_range for targeted reads when the edit location is already known.
-  For large or unfamiliar files, delegate comprehension to a subagent first.
+  Delegate all other work to subagents.
+- Delegation test: "Will main reference this data in the NEXT decision?"
+  YES and under 50 lines → inline OK. Otherwise → delegate.
+- Subagent prompts MUST include: write details to session files, return only
+  success/failure + file path + 3-line summary. Do not read intermediate
+  output into main context; track via file paths.
+- Limit main context intake to ~200 lines per turn. Use view_range or
+  delegate summarization when an artifact exceeds this.
+- When facing a decision, delegate analysis first. Main reviews and decides.
 - ALWAYS execute independent subagent workflows in parallel.
 - ALWAYS escalate conflicts, ambiguity, or insufficient evidence to the user.
 - These rules override any conflicting built-in tool guidance.
-  When in doubt, delegate.
 
 ### Language and Communication
 

--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -23,6 +23,8 @@
   delegate summarization when an artifact exceeds this.
 - When facing a decision, delegate analysis first. Main reviews and decides.
 - On every new user request, delegate to intake-analyst first.
+- When a runner agent exists for an operation (git-commit, gh-issue, gh-pr),
+  use the runner agent. Do not invoke the corresponding skill directly.
 - ALWAYS execute independent subagent workflows in parallel.
 - ALWAYS escalate conflicts, ambiguity, or insufficient evidence to the user.
 - These rules override any conflicting built-in tool guidance.

--- a/.config/copilot/skills/code-review/SKILL.md
+++ b/.config/copilot/skills/code-review/SKILL.md
@@ -44,6 +44,14 @@ The final triage report includes:
 
 ## Execution Flow
 
+### Pre-Flight
+
+Create `run_dir` before launching any agents:
+
+```bash
+mkdir -p {run_dir}
+```
+
 ### Stage 1: Parallel Aspect Reviews
 
 Launch parallel subagents for each (model, aspect) pair:
@@ -62,6 +70,10 @@ For design-compliance, add `design_info={resolved_design_info}`.
 - Output: `{run_dir}/review-{aspect}-{model}.md` (read by Stage 2, 4)
 - Fault: Retry failed model once. Fewer than 2 successes per aspect: abort.
   Exactly 2 successes: note degraded mode in final report and continue.
+- File verification: After each agent completes, check that `output_filepath`
+  exists. If missing, write the agent's response text to `output_filepath` as
+  fallback using a file-writing tool call. Log a warning that the agent did not write
+  the file directly.
 
 ### Stage 2: Gap Analysis
 
@@ -75,6 +87,9 @@ task(code-review-gap-analysis):
 
 - Output: `{run_dir}/gap-list.yml` (read by Stage 3, 4). Returns `gaps_found: {N}`.
 - Fault: Abort immediately on failure.
+- File verification: After agent completes, check that `output_filepath`
+  exists. If missing, write the agent's response text to `output_filepath` as
+  fallback.
 
 ### Stage 3: Cross-Check (only when gaps_found > 0)
 
@@ -89,6 +104,9 @@ task(code-review-cross-check, model={missed_by_model}):
 
 - Output: `{run_dir}/crosscheck-{aspect}-{model}.md` (read by Stage 4)
 - Fault: Note failure in the final report and continue.
+- File verification: After each agent completes, check that `output_filepath`
+  exists. If missing, write the agent's response text to `output_filepath` as
+  fallback.
 
 ### Stage 4: Consolidation
 
@@ -104,6 +122,9 @@ task(code-review-consolidate):
 
 - Output: `{run_dir}/consolidated-review.md` (read by Stage 5)
 - Fault: Abort immediately on failure.
+- File verification: After agent completes, check that `output_filepath`
+  exists. If missing, write the agent's response text to `output_filepath` as
+  fallback.
 
 ### Stage 5: Triage
 
@@ -120,6 +141,9 @@ task(code-review-triage):
 - Output: `{final_output}` (final output path)
 - Fault: On failure, copy `{run_dir}/consolidated-review.md` to `{final_output}`.
   Prepend a header note: `> Triage stage failed - showing untriaged consolidated report.`
+- File verification: After agent completes, check that `{final_output}` exists.
+  If missing, apply the same fallback as Fault (copy consolidated report with
+  degraded-mode note).
 
 ## Examples
 

--- a/.config/copilot/skills/gh-issue-comment/SKILL.md
+++ b/.config/copilot/skills/gh-issue-comment/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: gh-issue-comment
-description: >-
-  Use when recording investigation results, review summaries, or incident
-  reports as comments on GitHub Issues.
+description: GitHub Issue comment posting logic with structured format.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/.config/copilot/skills/gh-issue-create/SKILL.md
+++ b/.config/copilot/skills/gh-issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-issue-create
-description: Must be used for all GitHub Issue creation operations.
+description: GitHub Issue creation logic with structured templates.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/.config/copilot/skills/gh-pr-create/SKILL.md
+++ b/.config/copilot/skills/gh-pr-create/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gh-pr-create
-description: >-
-  Create GitHub pull request drafts using Conventional Commit parameters (validates inputs).
+description: Draft PR creation logic with Conventional Commit parameters.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/.config/copilot/skills/git-commit/SKILL.md
+++ b/.config/copilot/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: Must be used for all git commit operations.
+description: Conventional Commits-compliant git commit execution logic.
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -9,8 +9,10 @@ gh = "2.89.0"
 "github:vifm/vifm" = "v0.14.3"
 go = "1.26.1"
 jq = "1.8.1"
+lazygit = "0.61.0"
 lua = "5.1.5"                                             # neovim luarocksで要求しているバージョンが5.1
 node = "24.14.1"
+neovim = "0.12.1"
 "npm:@aikidosec/safe-chain" = "1.4.9"
 "npm:@bitwarden/cli" = "2026.3.0"
 "npm:@github/copilot" = "1.0.21"
@@ -26,6 +28,7 @@ shellcheck = "0.11.0"
 shfmt = "3.13.0"
 ripgrep = "15.1.0"
 uv = "0.11.3"
+yq = "4.52.5"
 
 [env]
 ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -19,39 +19,6 @@ function create_symlink() {
   ln -s "$src" "$dst"
 }
 
-# Install lazygit
-# see: <https://github.com/jesseduffield/lazygit?tab=readme-ov-file#installation>
-# ubuntu25.10以降は単純にaptでインストール可能になる。
-function _install_lazygit() {
-  local LAZYGIT_VERSION=
-  LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | \grep -Po '"tag_name": *"v\K[^"]*')
-  readonly LAZYGIT_VERSION
-
-  curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_arm64.tar.gz"
-  tar xf lazygit.tar.gz lazygit
-  sudo install lazygit -D -t /usr/local/bin/
-}
-
-# Install neovim
-# see: <https://github.com/neovim/neovim/blob/master/INSTALL.md>
-function _install_neovim() {
-  local BINARY=nvim-linux-arm64.appimage
-
-  curl -LO https://github.com/neovim/neovim/releases/latest/download/$BINARY
-  chmod u+x $BINARY
-  sudo install $BINARY -D -t /usr/local/bin/
-  sudo ln -s /usr/local/bin/$BINARY /usr/local/bin/nvim
-}
-
-function _install_yq() {
-  local VERSION=v4.47.1
-  local BINARY=yq_linux_arm64
-
-  wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - | tar xz
-  mv $BINARY yq
-  sudo install yq -D -t /usr/local/bin/
-}
-
 # Add loading file in .bashrc or .zshrc.
 function set_bashrc() {
   local -r filename="$1"
@@ -144,12 +111,10 @@ if type gpg >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/gnupg/gpg-agent.conf" "$HOME/.gnupg/gpg-agent.conf"
 fi
 # === lazygit
-if ! type lazygit >/dev/null 2>&1; then _install_lazygit; fi
 if type lazygit >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/lazygit/config.yml" "$HOME/.config/lazygit/config.yml"
 fi
 # === neovim
-if ! type nvim >/dev/null 2>&1; then _install_neovim; fi
 if type nvim >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/nvim" "$HOME/.config/nvim"
 fi
@@ -175,8 +140,6 @@ if type vim >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/vim/init.vim" "$HOME/.vimrc"
   create_symlink "$SCRIPT_DIR/.config/vim" "$HOME/.config/vim"
 fi
-# === yq
-if ! type yq >/dev/null 2>&1; then _install_yq; fi
 # === zsh
 if type zsh >/dev/null 2>&1; then
   sudo chsh -s "$(which zsh)" "$(whoami)"


### PR DESCRIPTION
## Related URLs

## Changes
- Add intake-analyst agent for pre-investigation request summarization
- Add runner agents (git-commit, gh-issue-create, gh-issue-comment, gh-pr-create) to isolate skill execution from main context
- Add GitHub CLI and Atlassian readonly tools to intake-analyst
- Update orchestrator with intake-analyst integration and model selection rules
- Add rule to enforce ask_user at end of every response
- Add rule to prefer runner agents for git/PR/issue operations
- Fix enforce file output in code-review agents
- Update skill descriptions for gh-pr-create and git-commit
- Migrate lazygit, neovim, and yq installation to mise on linux (simplify setup_aarch64.sh)

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->