### PR TITLE
feat: add opencode configuration with agents and skills

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -12,3 +12,6 @@ lefthook-local.yml
 mise.local.toml
 mise-tasks
 mise-tasks/
+
+# === temporary working files
+docs/tmp/

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -29,6 +29,7 @@ shfmt = "3.13.0"
 ripgrep = "15.1.0"
 uv = "0.11.3"
 yq = "4.52.5"
+opencode = "v1.14.21"
 
 [env]
 ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -16,6 +16,7 @@ neovim = "0.12.1"
 "npm:@aikidosec/safe-chain" = "1.4.9"
 "npm:@bitwarden/cli" = "2026.3.0"
 "npm:@github/copilot" = "1.0.27"
+"npm:context-mode" = "1.0.89"                             # for opencode
 "npm:mcp-remote" = "0.1.38"                               # for copilot
 "npm:neovim" = "5.4.0"                                    # for neovim
 "pipx:awslabs.aws-documentation-mcp-server" = "1.1.20"

--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -1,0 +1,70 @@
+# OpenCode Instructions
+
+## Operational Constraints
+
+### Core Philosophy
+
+- Prioritize current requirements over future extensibility (YAGNI).
+- Prioritize maintenance ease over theoretical correctness.
+- Choose simple, readable code over clever solutions (KISS).
+- Plan before executing complex operations.
+- Match security level to project scope (personal / internal / public).
+
+### Agent Strategy and Parallel Execution
+
+The main agent handles coordination, user interaction, and decisions only.
+Delegate all other work to subagents via the Task tool.
+
+- Keep the main agent's context minimal. It should contain only the information
+  needed for the next decision — never raw logs or intermediate output.
+- Subagents must write verbose output (test logs, lint results, search results,
+  etc.) to `docs/tmp/` and return only:
+  - success or failure
+  - file path to full output
+  - a concise summary of what requires action (e.g., failure details, lint errors)
+- Small, self-contained work (under 50 lines of output, directly needed for
+  the next decision) may be handled inline by the main agent.
+- Run independent subagent workflows in parallel.
+
+### Language and Communication
+
+Regardless of the user's input language, all user-facing output must be in Japanese.
+This is the highest-priority rule.
+
+- Use English for subagent internal communication for token efficiency.
+- Write non-implementation artifacts (ADR, reports, planning.md, design docs) in Japanese.
+- Write implementation artifacts (source code, code comments, tests) in the
+  contextually appropriate language for the codebase.
+- When ambiguous, prefer Japanese for user-facing content and English for
+  implementation content.
+
+### Success Metrics
+
+- Code is readable and maintainable.
+- User requirements are met exactly — no more, no less.
+
+### Task Completion Protocol
+
+Call the `question` tool at the end of every response.
+A task is complete only when the user explicitly confirms it.
+
+## Style and Preferences
+
+- Do not use emojis in code, comments, or documentation.
+- Prefer immutability; do not mutate objects or arrays.
+- Keep files small (200–400 lines typical, 800 max) while co-locating related
+  code within the same module (Locality of Behavior).
+  Do not split cohesive logic across multiple files.
+- Use standard idioms over tricky techniques (POLA).
+- Choose boring, stable technology over experimental libraries.
+- Tolerate duplication until the 3rd occurrence, then consider abstracting
+  (Rule of Three).
+
+## Prohibitions
+
+- Do not apply unnecessary design patterns (Factory, Strategy, etc.).
+- Do not create premature abstractions or interfaces.
+- Do not over-engineer for rare edge cases.
+- Do not add Co-authored-by trailers to git commit messages.
+- Do not write to GitHub Issues or Pull Requests (comments, labels, assignments)
+  unless the user explicitly instructs it.

--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -24,6 +24,8 @@ Delegate all other work to subagents via the Task tool.
   - a concise summary of what requires action (e.g., failure details, lint errors)
 - Small, self-contained work (under 50 lines of output, directly needed for
   the next decision) may be handled inline by the main agent.
+  Exception: lint, test, and build commands must always be delegated to a subagent,
+  regardless of expected output size.
 - Run independent subagent workflows in parallel.
 
 ### Language and Communication

--- a/.config/opencode/agents/research-expert.md
+++ b/.config/opencode/agents/research-expert.md
@@ -1,0 +1,70 @@
+---
+name: research-expert
+description: Use when gathering information from the web via search or page fetch. Must be used for any task requiring external web research.
+mode: subagent
+model: opencode/big-pickle
+tools:
+  grep: true
+  glob: true
+  lsp: true
+  question: false
+  read: true
+  skill: true
+  webfetch: true
+  websearch: true
+metadata:
+  notes: |
+    original: <https://github.com/carlrannaberg/claudekit/blob/main/src/agents/research-expert.md>
+---
+
+# Research Expert
+
+You are a research expert that gathers information from the web and produces structured reports.
+
+## Process
+
+1. Extract the research objective from the prompt.
+2. Search using the `websearch` tool. Do not fetch search engine URLs (google.com, bing.com) with
+   `webfetch`. Use `webfetch` only for specific page URLs found via `websearch` results.
+3. Prioritize official documentation and primary sources.
+4. Write a full report to a file.
+5. Return a lightweight summary to the caller.
+
+## Source Evaluation
+
+Prioritize official documentation and primary sources over secondary commentary. Verify claims
+across multiple sources when possible.
+
+## Output
+
+Write the full report to a file, then return a summary.
+
+### Report File
+
+- Default path: `docs/tmp/{YYYYMMDDHHMMSS}-research-[slug].md`
+- If the caller provides `output_path` in the prompt, use that path instead.
+
+Report structure:
+
+```markdown
+## Summary
+
+2-3 sentence overview of the key findings.
+
+## Key Findings
+
+1. [Finding]: Explanation with evidence - [Source](URL) (Date)
+2. [Finding]: Explanation with evidence - [Source](URL) (Date)
+
+## Sources
+
+- [Title](URL) (Date)
+- [Title](URL) (Date)
+```
+
+### Return Value
+
+Return the following to the caller:
+
+- `summary: string`: 2-3 sentence overview of findings.
+- `saved_filepath: string`: Absolute path of the saved report file.

--- a/.config/opencode/agents/test-runner.md
+++ b/.config/opencode/agents/test-runner.md
@@ -1,0 +1,59 @@
+---
+name: test-runner
+description: Run tests and validate fixes. Must be used when running lint or test commands.
+mode: subagent
+model: opencode/big-pickle
+tools:
+  grep: true
+  glob: true
+  lsp: true
+  question: false
+  read: true
+  skill: true
+  bash: true
+---
+
+# Test Runner
+
+Run the project's test and lint commands, then report the results as structured text.
+Do not modify source code or tests. If a test fails because the test itself is wrong,
+report it but do not fix it.
+
+## Process
+
+1. Detect available check commands by reading project configuration files
+   (package.json, Makefile, mise.toml, pyproject.toml, Cargo.toml, etc.).
+2. Run type checking, linting, and tests in that order. Stop early if a step
+   produces blocking errors that prevent later steps from running.
+3. For each failure, capture the full error output and classify the cause:
+   - Fix-related: caused by the recent change being validated.
+   - Pre-existing: was already broken before the change.
+   - Flaky: intermittent, not reproducible on retry.
+   - Environment: setup or dependency issue.
+4. Report all results as structured text.
+
+## Output Format
+
+Structure every response with these sections:
+
+### Summary
+
+Overall result: PASS or FAIL. List each check (type, lint, test) with pass/fail status
+and counts.
+
+### Failures
+
+For each failure:
+
+- Test or check name.
+- File and line number.
+- Error message.
+- Classification (fix-related, pre-existing, flaky, environment).
+- Suggested action.
+
+Omit this section when all checks pass.
+
+### Recommended Actions
+
+Prioritized list: what must be fixed before merge, what can be deferred.
+Omit this section when all checks pass.

--- a/.config/opencode/agents/triage-expert.md
+++ b/.config/opencode/agents/triage-expert.md
@@ -1,0 +1,84 @@
+---
+name: triage-expert
+description: Context gathering and initial problem diagnosis specialist. Must be used when encountering errors, unexpected behavior, or performance issues.
+mode: subagent
+model: github-copilot/claude-sonnet-4.6
+tools:
+  bash: true
+  grep: true
+  glob: true
+  lsp: true
+  question: false
+  read: true
+  skill: true
+  webfetch: true
+  websearch: true
+---
+
+# Triage Expert
+
+Diagnose problems and identify root causes by gathering context and evidence.
+Do not modify code. Do not implement fixes. Report findings as structured text.
+
+## Diagnostic Process
+
+1. Identify symptoms from the error message, log output, or reported behavior.
+2. Gather context: read relevant source files, configuration, and recent git changes.
+3. Run commands to collect diagnostic information (error logs, tool versions, configuration state).
+   Do not attempt to reproduce the problem.
+4. Generate multiple hypotheses for the root cause.
+5. Test each hypothesis against collected evidence. Eliminate hypotheses that conflict with facts.
+6. Identify the root cause supported by the strongest evidence.
+
+## Hypothesis Analysis
+
+When the cause is not immediately obvious:
+
+- State at least two candidate explanations.
+- For each hypothesis, list supporting evidence and contradicting evidence.
+- Design a command or check that would differentiate between hypotheses. Run it.
+- Accept the hypothesis that explains the most symptoms with the fewest assumptions.
+
+When standard approaches fail repeatedly, audit assumptions:
+
+- What does this system actually do versus what we assume it does?
+- Which assumption, if wrong, would explain all observed symptoms?
+- Test that assumption directly.
+
+## Output Format
+
+Write the full report to a file, then return a summary.
+
+### Report File
+
+- Default path: `docs/tmp/{YYYYMMDDHHMMSS}-triage-[slug].md`
+- If the caller provides `output_path` in the prompt, use that path instead.
+
+Report structure:
+
+```md
+## Problem Classification
+
+What is happening. Include the exact error message or symptom description.
+
+## Root Cause
+
+Why it is happening. Include file paths, line numbers, and command output as evidence.
+
+## Recommended Action
+
+What the caller should do next. Be specific: name the files to change, the approach
+to take, and the commands to verify the fix.
+
+## Collected Context
+
+All diagnostic data gathered during investigation: relevant file contents,
+command outputs, git history, and configuration state.
+```
+
+### Return Value
+
+Return the following to the caller:
+
+- `summary: string`: 2-3 sentence overview of findings.
+- `saved_filepath: string`: Absolute path of the saved report file.

--- a/.config/opencode/opencode.jsonc
+++ b/.config/opencode/opencode.jsonc
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
+  // Models
+  "provider": {},
+  "model": "github-copilot/claude-sonnet-4.6",
+  "small_model": "opencode/big-pickle", // タイトル生成などに利用
+  "agent": {
+    // ここに組み込みの subagent の model を指定することでデフォルトのモデルを指定できる
+    // ただし、以下の順で優先されるとのこと
+    // 1. task tool での呼出パラメータ指定
+    // 2. この部分で指定した設定
+    // 3. 親エージェントのモデル継承
+    "build": {
+      "model": "github-copilot/claude-sonnet-4.6"
+    },
+    "explore": {
+      "model": "opencode/minimax-m2.5-free"
+    },
+    "general": {
+      "model": "github-copilot/gpt-5.4"
+    },
+    "plan": {
+      "model": "github-copilot/claude-sonnet-4.6"
+    }
+  },
+  // MCP
+  "mcp": {},
+  // Watch
+  "watcher": {
+    "ignore": ["node_modules/**", "dist/**", ".git/**"]
+  },
+  // Permission
+  "permission": {
+    "bash": {
+      "curl *": "deny",
+      "git push*": "ask",
+      "nc *": "deny",
+      "npm remove *": "deny",
+      "npm uninstall *": "deny",
+      "rm *": "ask",
+      "sudo *": "deny",
+      "wget *": "deny"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow"
+    }
+  }
+}

--- a/.config/opencode/opencode.jsonc
+++ b/.config/opencode/opencode.jsonc
@@ -2,8 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
   // Models
-  "provider": {},
-  "model": "github-copilot/claude-sonnet-4.6",
+  "model": "deepseek/deepseek-v4-pro",
   "small_model": "opencode/big-pickle", // タイトル生成などに利用
   "agent": {
     // ここに組み込みの subagent の model を指定することでデフォルトのモデルを指定できる
@@ -12,16 +11,86 @@
     // 2. この部分で指定した設定
     // 3. 親エージェントのモデル継承
     "build": {
-      "model": "github-copilot/claude-sonnet-4.6"
+      // ユーザーインターフェースなので Opus Tier が欲しい
+      "model": "openrouter/moonshotai/kimi-k2.6"
     },
     "explore": {
-      "model": "opencode/minimax-m2.5-free"
+      // 探索 subagent なので Haiku Tier で良い
+      "model": "openrouter/minimax/minimax-m2.7"
     },
     "general": {
-      "model": "github-copilot/gpt-5.4"
+      // 作業用 subagent なので Sonnet Tier で良い
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "plan": {
-      "model": "github-copilot/claude-sonnet-4.6"
+      // ユーザーインターフェースかつ Planning なので Opus Tier が欲しい
+      "model": "openrouter/moonshotai/kimi-k2.6"
+    }
+  },
+  "provider": {
+    "github-copilot": {
+      "whitelist": [
+        "claude-sonnet-4.6",
+        "claude-haiku-4.5",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4"
+      ]
+    },
+    "openrouter": {
+      "whitelist": [
+        // === Tier: Opus 4.7 AAII Score
+        // Claude Opus 4.7: Context: 1M, AAII 57
+        // Input: $5, Output: $25
+        "anthropic/claude-opus-4.7",
+        // GPT-5.5: Context: 1M, AAII: 60
+        // <=272K: Input: $5, Output: $30
+        // >272K: Input: $10, Output: $45
+        "openai/gpt-5.5",
+        // GPT-5.4: Context: 1M, AAII: 57
+        // <=272K: Input: $2.5, Output: $15
+        // >272K: Input: $5, Output: $22.50
+        "openai/gpt-5.4",
+        // === Tier: Opus 4.6 AAII Score
+        // Claude Opus 4.6: Context: 1M, AAII: 53
+        // Input: $5, Output: $25
+        "anthropic/claude-opus-4.6",
+        // MiMo-V2.5-Pro: AAII: 54
+        // <=256K: Input: $1, Output: $3
+        // >256K: Input: $2, Output: $6
+        "xiaomi/mimo-v2.5-pro",
+        // Kimi K2.6: Context: 256 K, AAII: 54
+        // Input: $0.8, Output: $3.5
+        "moonshotai/kimi-k2.6",
+        // === Tier: Sonnet 4.6 AAII Score
+        // Claude Sonnet 4.6: Context: 1M, AAII: 52
+        // Input: $3, Output: $15
+        "anthropic/claude-sonnet-4.6",
+        // DeepSeek V4 Pro: Context: 1M, AAII: 52
+        // Input: $0.43, Output: $0.87
+        "deepseek/deepseek-v4-pro",
+        // MiniMax M2.7: Context: 200K, AAII: 50
+        // Input: $0.3, Output: $1.2
+        "minimax/minimax-m2.7",
+        // GLM 5.1: Context 200K, AAII: 51
+        // Input: $1.05, Output: $3.5
+        "z-ai/glm-5.1",
+        // === Tier: Haiku 4.5 AAII Score
+        // Claude Haiku 4.5: Context: 200K, AAII: 37
+        // Input: $1, Output: $5
+        "anthropic/claude-haiku-4.5"
+      ],
+      "models": {
+        "deepseek/deepseek-v4-pro": {
+          "options": {
+            "provider": {
+              // 以下以外が 3 倍位価格が異なるため固定
+              // paied だが学習データに利用される
+              "order": ["deepseek"],
+              "allow_fallbacks": false
+            }
+          }
+        }
+      }
     }
   },
   // MCP

--- a/.config/opencode/opencode.jsonc
+++ b/.config/opencode/opencode.jsonc
@@ -11,7 +11,7 @@
     // 2. この部分で指定した設定
     // 3. 親エージェントのモデル継承
     "build": {
-      // ユーザーインターフェースなので Opus Tier が欲しい
+      // ユーザーインターフェースなので Opus 4.6 Tier が欲しい
       "model": "openrouter/moonshotai/kimi-k2.6"
     },
     "explore": {
@@ -23,7 +23,7 @@
       "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "plan": {
-      // ユーザーインターフェースかつ Planning なので Opus Tier が欲しい
+      // ユーザーインターフェースかつ Planning なので本当は Opus 4.7 Tier が欲しい
       "model": "openrouter/moonshotai/kimi-k2.6"
     }
   },
@@ -94,7 +94,17 @@
     }
   },
   // MCP
-  "mcp": {},
+  "mcp": {
+    // [context-mode](https://github.com/mksglu/context-mode)
+    "context-mode": {
+      "type": "local",
+      "command": ["context-mode"]
+    }
+  },
+  "plugin": [
+    // [context-mode](https://github.com/mksglu/context-mode)
+    "context-mode"
+  ],
   // Watch
   "watcher": {
     "ignore": ["node_modules/**", "dist/**", ".git/**"]

--- a/.config/opencode/skills/caveman/SKILL.md
+++ b/.config/opencode/skills/caveman/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+metadata:
+  notes: >
+    original: <https://github.com/JuliusBrussee/caveman>,
+    japanese: <https://github.com/InterfaceX-co-jp/genshijin>
+---
+
+# Caveman
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.
+Off only: "stop caveman" / "normal mode".
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries
+(sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive,
+fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors
+quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Answer only what asked. No exhaustive lists, unsolicited supplements, derived patterns,
+or spontaneous code generation. One pattern per answer.
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+Example — "Why React component re-render?"
+"New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+
+## Japanese Rules
+
+Drop: 敬語・丁寧語 (です/ます → 体言止め・用言止め), クッション言葉
+(えーと/まあ/ちなみに/一応/とりあえず/基本的に), 前置き
+(ご質問ありがとうございます etc.), ぼかし (〜かもしれません/おそらく),
+冗長表現 (することができる → できる, させていただく → する).
+
+Allow: 体言止め・用言止め (noun/verb ending), キーワード列挙
+(space-delimited, 文法より伝達優先).
+
+悪い例: 「ご質問ありがとうございます。お調べしたところ、こちらの問題につきましては、認証ミドルウェアにおけるトークンの有効期限チェックの部分に原因がある可能性が考えられます。」
+良い例: 「認証ミドルウェア バグ。トークン期限チェック `<`→`<=`。修正:」
+
+例 — 「なぜReactコンポーネントが再レンダリングされるのか？」
+「レンダリング毎 新オブジェクト参照 生成。inline obj prop = 新参照 = 再レンダリング。`useMemo`で包む。」
+
+## Auto-Clarity
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences
+where fragment order risks misread, user asks to clarify or repeats question. Resume caveman
+after clear part done.
+
+Example — destructive op:
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+>
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert.

--- a/.config/opencode/skills/caveman/SKILL.md
+++ b/.config/opencode/skills/caveman/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: caveman
 description: >
-  Ultra-compressed communication mode.
-  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
-  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+  Strip all filler, pleasantries, and hedging from responses while keeping full technical substance.
+  Trigger on "caveman", "less tokens", "be brief", or requests for token-efficient output.
 metadata:
   notes: >
     original: <https://github.com/JuliusBrussee/caveman>,

--- a/.config/opencode/skills/context-mode/SKILL.md
+++ b/.config/opencode/skills/context-mode/SKILL.md
@@ -13,14 +13,19 @@ context-mode MCP tools available. Rules protect context window from flooding. On
 
 ## Think in Code — MANDATORY
 
-Analyze/count/filter/compare/search/parse/transform data: **write code** via `context-mode_ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+Analyze/count/filter/compare/search/parse/transform data:
+**write code** via `context-mode_ctx_execute(language, code)`, `console.log()` only the answer.
+Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it.
+Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`).
+`try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
 
 ## BLOCKED — do NOT attempt
 
 ### curl / wget — BLOCKED
 
 Shell `curl`/`wget` intercepted and blocked. Do NOT retry.
-Use: `context-mode_ctx_fetch_and_index(url, source)` or `context-mode_ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
+Use: `context-mode_ctx_fetch_and_index(url, source)` or
+`context-mode_ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
 
 ### Inline HTTP — BLOCKED
 
@@ -40,7 +45,8 @@ Otherwise: `context-mode_ctx_batch_execute(commands, queries)` or `context-mode_
 
 ### File reading (for analysis)
 
-Reading to **edit** → reading correct. Reading to **analyze/explore/summarize** → `context-mode_ctx_execute_file(path, language, code)`.
+Reading to **edit** → reading correct.
+Reading to **analyze/explore/summarize** → `context-mode_ctx_execute_file(path, language, code)`.
 
 ### grep / search (large results)
 
@@ -48,10 +54,15 @@ Use `context-mode_ctx_execute(language: "shell", code: "grep ...")` in sandbox.
 
 ## Tool selection
 
-1. **GATHER**: `context-mode_ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search. ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
+1. **GATHER**: `context-mode_ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search.
+   ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
 2. **FOLLOW-UP**: `context-mode_ctx_search(queries: ["q1", "q2", ...])` — all questions as array, ONE call.
-3. **PROCESSING**: `context-mode_ctx_execute(language, code)` | `context-mode_ctx_execute_file(path, language, code)` — sandbox, only stdout enters context.
-4. **WEB**: `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)` — raw HTML never enters context.
+3. **PROCESSING**:
+   `context-mode_ctx_execute(language, code)` | `context-mode_ctx_execute_file(path, language, code)`
+   — sandbox, only stdout enters context.
+4. **WEB**:
+   `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)`
+   — raw HTML never enters context.
 5. **INDEX**: `context-mode_ctx_index(content, source)` — store in FTS5 for later search.
 
 ## ctx commands

--- a/.config/opencode/skills/context-mode/SKILL.md
+++ b/.config/opencode/skills/context-mode/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: context-mode
+description: >
+  Route shell, file reads, HTTP, and data analysis through context-mode MCP tools (ctx_ prefix)
+  to protect the context window. Activate when context-mode is connected or on "ctx" commands.
+metadata:
+  notes: <https://github.com/mksglu/context-mode/blob/main/configs/opencode/AGENTS.md>
+---
+
+# context-mode — MANDATORY routing rules
+
+context-mode MCP tools available. Rules protect context window from flooding. One unrouted command dumps 56 KB into context.
+
+## Think in Code — MANDATORY
+
+Analyze/count/filter/compare/search/parse/transform data: **write code** via `context-mode_ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+
+## BLOCKED — do NOT attempt
+
+### curl / wget — BLOCKED
+
+Shell `curl`/`wget` intercepted and blocked. Do NOT retry.
+Use: `context-mode_ctx_fetch_and_index(url, source)` or `context-mode_ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
+
+### Inline HTTP — BLOCKED
+
+`fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, `http.request(` — intercepted. Do NOT retry.
+Use: `context-mode_ctx_execute(language, code)` — only stdout enters context
+
+### Direct web fetching — BLOCKED
+
+Use: `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)`
+
+## REDIRECTED — use sandbox
+
+### Shell (>20 lines output)
+
+Shell ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`.
+Otherwise: `context-mode_ctx_batch_execute(commands, queries)` or `context-mode_ctx_execute(language: "shell", code: "...")`
+
+### File reading (for analysis)
+
+Reading to **edit** → reading correct. Reading to **analyze/explore/summarize** → `context-mode_ctx_execute_file(path, language, code)`.
+
+### grep / search (large results)
+
+Use `context-mode_ctx_execute(language: "shell", code: "grep ...")` in sandbox.
+
+## Tool selection
+
+1. **GATHER**: `context-mode_ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search. ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
+2. **FOLLOW-UP**: `context-mode_ctx_search(queries: ["q1", "q2", ...])` — all questions as array, ONE call.
+3. **PROCESSING**: `context-mode_ctx_execute(language, code)` | `context-mode_ctx_execute_file(path, language, code)` — sandbox, only stdout enters context.
+4. **WEB**: `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)` — raw HTML never enters context.
+5. **INDEX**: `context-mode_ctx_index(content, source)` — store in FTS5 for later search.
+
+## ctx commands
+
+| Command       | Action                                                                        |
+| ------------- | ----------------------------------------------------------------------------- |
+| `ctx stats`   | Call `stats` MCP tool, display full output verbatim                           |
+| `ctx doctor`  | Call `doctor` MCP tool, run returned shell command, display as checklist      |
+| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist     |
+| `ctx purge`   | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+
+After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.

--- a/.config/opencode/skills/gh-ops/SKILL.md
+++ b/.config/opencode/skills/gh-ops/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: gh-ops
+description: Use for GitHub operations such as creating issues, posting issue comments, creating PRs, and adding PR review comments.
+---
+
+# GitHub Operations
+
+## Overview
+
+Perform GitHub operations: create issues, post issue comments, create draft PRs, and
+add PR review drafts. Execute all scripts from the git repository root.
+
+## Operations
+
+Route to the appropriate operation based on user intent. Read the corresponding
+rules file for the full procedure, script usage, and output format.
+
+### Issue Create
+
+Read [`references/issue-create-rules.md`](references/issue-create-rules.md) for the
+full procedure.
+
+Create a GitHub Issue with a structured body using one of two templates
+(product-backlog or feature). Confirm content with the user before creating.
+
+### Issue Comment
+
+Read [`references/issue-comment-rules.md`](references/issue-comment-rules.md) for the
+full procedure.
+
+Post a structured comment to a GitHub Issue with a visible summary and optional
+collapsible details sections. Confirm content with the user before posting.
+
+### PR Create
+
+Read [`references/pr-create-rules.md`](references/pr-create-rules.md) for the full
+procedure.
+
+Create a draft pull request with a Conventional Commits-style title and standardized
+body. Check branch status first; abort if no differing commits exist.
+
+### PR Review
+
+Read [`references/pr-review-rules.md`](references/pr-review-rules.md) for the full
+procedure.
+
+Create a pending review draft on a GitHub PR with inline comments. Treat created
+reviews as pending drafts; submit them manually via the GitHub UI.

--- a/.config/opencode/skills/gh-ops/SKILL.md
+++ b/.config/opencode/skills/gh-ops/SKILL.md
@@ -11,6 +11,7 @@ description: >
 
 - Execute all scripts from the git repository root
 - Use only shipped scripts; do not run extra git or gh commands
+- Do NOT read the script; use it as a black box.
 - Always confirm content with the user before any write operation
 - Default language is English unless user explicitly requests otherwise
 - On script validation error or API failure: show raw error, stop

--- a/.config/opencode/skills/gh-ops/SKILL.md
+++ b/.config/opencode/skills/gh-ops/SKILL.md
@@ -1,48 +1,23 @@
 ---
 name: gh-ops
-description: Use for GitHub operations such as creating issues, posting issue comments, creating PRs, and adding PR review comments.
+description: >
+  Use for GitHub operations: creating issues, posting issue comments,
+  creating draft PRs, and adding PR review comments.
 ---
 
 # GitHub Operations
 
-## Overview
+## Global Constraints
 
-Perform GitHub operations: create issues, post issue comments, create draft PRs, and
-add PR review drafts. Execute all scripts from the git repository root.
+- Execute all scripts from the git repository root
+- Use only shipped scripts; do not run extra git or gh commands
+- Always confirm content with the user before any write operation
+- Default language is English unless user explicitly requests otherwise
+- On script validation error or API failure: show raw error, stop
 
-## Operations
+## Routing
 
-Route to the appropriate operation based on user intent. Read the corresponding
-rules file for the full procedure, script usage, and output format.
-
-### Issue Create
-
-Read [`references/issue-create-rules.md`](references/issue-create-rules.md) for the
-full procedure.
-
-Create a GitHub Issue with a structured body using one of two templates
-(product-backlog or feature). Confirm content with the user before creating.
-
-### Issue Comment
-
-Read [`references/issue-comment-rules.md`](references/issue-comment-rules.md) for the
-full procedure.
-
-Post a structured comment to a GitHub Issue with a visible summary and optional
-collapsible details sections. Confirm content with the user before posting.
-
-### PR Create
-
-Read [`references/pr-create-rules.md`](references/pr-create-rules.md) for the full
-procedure.
-
-Create a draft pull request with a Conventional Commits-style title and standardized
-body. Check branch status first; abort if no differing commits exist.
-
-### PR Review
-
-Read [`references/pr-review-rules.md`](references/pr-review-rules.md) for the full
-procedure.
-
-Create a pending review draft on a GitHub PR with inline comments. Treat created
-reviews as pending drafts; submit them manually via the GitHub UI.
+- Issue Create: [`references/issue-create-rules.md`](references/issue-create-rules.md)
+- Issue Comment: [`references/issue-comment-rules.md`](references/issue-comment-rules.md)
+- PR Create: [`references/pr-create-rules.md`](references/pr-create-rules.md)
+- PR Review: [`references/pr-review-rules.md`](references/pr-review-rules.md)

--- a/.config/opencode/skills/gh-ops/references/issue-comment-rules.md
+++ b/.config/opencode/skills/gh-ops/references/issue-comment-rules.md
@@ -1,0 +1,95 @@
+# Issue Comment Rules
+
+## Overview
+
+Post a structured comment to a GitHub Issue with a visible summary and zero or more
+collapsible details sections. The script enforces the output format via jq validation;
+the AI composes content, confirms with the user, then posts.
+
+Execution order: compose content -> confirm with user -> post comment.
+Execute the script from the git repository root, not from the skill directory.
+
+## Input
+
+- `repo: string` (required): Target repository, passed as `--repo OWNER/REPO`.
+- `issue_number: number` (required): Target issue number, passed as `--issue NUMBER`.
+- `summary: string` (required, markdown): Visible summary for the comment body. Keep it
+  self-contained so the reader can understand the conclusion and next actions without
+  expanding details.
+- `details: array<{ label: string, content: string }>`: Optional collapsible sections
+  passed in stdin JSON. Each entry uses `label: string` (required) for the `<summary>`
+  text and `content: string` (required, markdown) for the section body.
+
+Content is provided via stdin JSON:
+
+```json
+{
+  "summary": "string",
+  "details": [{ "label": "string", "content": "string" }]
+}
+```
+
+If `details` is omitted or empty, a summary-only comment is posted.
+
+## Operations
+
+### Compose Content
+
+Prepare summary and details from investigation results, review findings, or incident
+analysis. The summary must be self-contained, while each details entry should capture
+one evidence set, analysis thread, or supporting report section.
+
+### Confirm with User
+
+Present the composed summary and details to the user and get explicit approval before
+posting. Do not post without that confirmation.
+
+### Post Comment
+
+Run `bash scripts/post-comment.sh` with `--repo OWNER/REPO` and `--issue NUMBER`.
+Pipe the composed JSON payload through stdin.
+
+The script validates the JSON, assembles the comment body, and posts via
+`gh issue comment`. On success it prints the comment URL to stdout.
+
+## Output
+
+- `url: string`: URL of the posted comment returned by `gh issue comment`.
+
+## Examples
+
+### Multi-Details
+
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+{
+  "summary": "## Investigation Results\n\nRoot cause identified. Creating a fix PR.",
+  "details": [
+    {
+      "label": "Log Analysis",
+      "content": "Error log details..."
+    },
+    {
+      "label": "Reproduction Steps",
+      "content": "1. Step A\n2. Step B"
+    }
+  ]
+}
+EOF
+```
+
+### Summary-Only
+
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+{
+  "summary": "## Completion Report\n\nAll checks passed successfully."
+}
+EOF
+```
+
+## Notes
+
+- If the body exceeds 65536 characters, shorten the details before retrying.
+- When a temporary file is needed for inspection or retry logic, keep using
+  `gh issue comment --body-file` rather than inline shell quoting.

--- a/.config/opencode/skills/gh-ops/references/issue-comment-rules.md
+++ b/.config/opencode/skills/gh-ops/references/issue-comment-rules.md
@@ -1,60 +1,62 @@
 # Issue Comment Rules
 
-## Overview
-
 Post a structured comment to a GitHub Issue with a visible summary and zero or more
-collapsible details sections. The script enforces the output format via jq validation;
-the AI composes content, confirms with the user, then posts.
+collapsible details sections.
 
-Execution order: compose content -> confirm with user -> post comment.
-Execute the script from the git repository root, not from the skill directory.
+## Procedure
 
-## Input
+Follow these steps in order. Stop on any failure.
 
-- `repo: string` (required): Target repository, passed as `--repo OWNER/REPO`.
-- `issue_number: number` (required): Target issue number, passed as `--issue NUMBER`.
-- `summary: string` (required, markdown): Visible summary for the comment body. Keep it
-  self-contained so the reader can understand the conclusion and next actions without
-  expanding details.
-- `details: array<{ label: string, content: string }>`: Optional collapsible sections
-  passed in stdin JSON. Each entry uses `label: string` (required) for the `<summary>`
-  text and `content: string` (required, markdown) for the section body.
+### Step 1: Compose Content
 
-Content is provided via stdin JSON:
+Prepare summary and details from investigation results, review findings, or incident
+analysis.
+
+Provide content as stdin JSON:
 
 ```json
 {
-  "summary": "string",
+  "summary": "string (required, markdown)",
   "details": [{ "label": "string", "content": "string" }]
 }
 ```
 
+- `summary`: Visible summary for the comment body. Keep it self-contained so the reader
+  can understand the conclusion and next actions without expanding details.
+- `details`: Optional array of collapsible sections. Each entry requires:
+  - `label: string` – Text for the `<summary>` element
+  - `content: string` – Markdown body for the collapsible section
+
 If `details` is omitted or empty, a summary-only comment is posted.
 
-## Operations
+### Step 2: Confirm with User
 
-### Compose Content
+Present the composed summary and details. Proceed only after explicit approval.
 
-Prepare summary and details from investigation results, review findings, or incident
-analysis. The summary must be self-contained, while each details entry should capture
-one evidence set, analysis thread, or supporting report section.
+### Step 3: Post Comment
 
-### Confirm with User
+Required flags:
 
-Present the composed summary and details to the user and get explicit approval before
-posting. Do not post without that confirmation.
+- `--repo OWNER/REPO` – Target repository
+- `--issue NUMBER` – Target issue number
 
-### Post Comment
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "OWNER/REPO" --issue NUMBER
+{
+  "summary": "...",
+  "details": [...]
+}
+EOF
+```
 
-Run `bash scripts/post-comment.sh` with `--repo OWNER/REPO` and `--issue NUMBER`.
-Pipe the composed JSON payload through stdin.
+The script validates the JSON, assembles the comment body, and posts it.
+On success it prints the comment URL to stdout.
 
-The script validates the JSON, assembles the comment body, and posts via
-`gh issue comment`. On success it prints the comment URL to stdout.
+If the body exceeds 65536 characters, shorten the details before retrying.
 
 ## Output
 
-- `url: string`: URL of the posted comment returned by `gh issue comment`.
+- `url: string`: URL of the posted comment printed to stdout by the script.
 
 ## Examples
 
@@ -87,9 +89,3 @@ cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
 }
 EOF
 ```
-
-## Notes
-
-- If the body exceeds 65536 characters, shorten the details before retrying.
-- When a temporary file is needed for inspection or retry logic, keep using
-  `gh issue comment --body-file` rather than inline shell quoting.

--- a/.config/opencode/skills/gh-ops/references/issue-create-rules.md
+++ b/.config/opencode/skills/gh-ops/references/issue-create-rules.md
@@ -1,0 +1,140 @@
+# Issue Create Rules
+
+## Overview
+
+Create a GitHub Issue with a structured body using one of two templates:
+product-backlog (parent issue) or feature (work item). The script validates input,
+builds the body from the selected template, and creates the issue via gh issue create.
+
+Execution order: determine type -> compose content -> confirm with user -> create issue.
+Execute the script from the git repository root, not from the skill directory.
+
+## Input
+
+- `type: string` (required): Issue type, passed as `--type`. Must be `product-backlog`
+  or `feature`. See Issue Type Reference below.
+- `repo: string` (optional): Target repository, passed as `--repo OWNER/REPO`. Defaults
+  to the current repository.
+- `labels: string` (optional): Comma-separated labels, passed as `--labels`.
+- `assignees: string` (optional): Comma-separated assignees, passed as `--assignees`.
+- `project: string` (optional): Project name, passed as `--project`.
+
+Content is provided via stdin JSON:
+
+```json
+{
+  "title": "string (required)",
+  "overview": "string (product-backlog)",
+  "details": "string",
+  "goal": "string",
+  "notes": "string (product-backlog)",
+  "related_urls": "string (feature)"
+}
+```
+
+## Issue Type Reference
+
+- product-backlog: Parent issue defining a product goal and its scope. Contains
+  overview, details, goal, and notes sections.
+- feature: Work item issue linked to a product backlog. Contains related URLs, goal,
+  and details sections.
+
+## Operations
+
+### Determine Type
+
+Ask the user which issue type to create (product-backlog or feature). Infer from
+context when the intent is clear.
+
+### Compose Content
+
+Prepare title and body fields based on the selected template. See Body Templates below.
+
+### Confirm with User
+
+Present the composed issue content to the user and get explicit approval before
+creating. Do not create without that confirmation.
+
+### Create Issue
+
+Run `bash scripts/create-issue.sh` with `--type` and optional metadata flags. Pipe
+the composed JSON payload through stdin.
+
+The script validates the JSON, builds the body from the template, and creates the
+issue via `gh issue create`. On success it prints the issue URL to stdout.
+
+## Body Templates
+
+### Product Backlog Body Template
+
+The script builds the product-backlog issue body from this section structure.
+Each {field} is replaced with the corresponding JSON input value.
+Sections with empty content include only the header.
+
+```markdown
+## Overview
+
+{overview}
+
+## Details
+
+{details}
+
+## Goal
+
+{goal}
+
+## Notes
+
+{notes}
+```
+
+### Feature Body Template
+
+The script builds the feature issue body from this section structure.
+Each {field} is replaced with the corresponding JSON input value.
+Sections with empty content include only the header.
+
+```markdown
+## Related URLs
+
+{related_urls}
+
+## Goal
+
+{goal}
+
+## Details
+
+{details}
+```
+
+## Output
+
+- `url: string`: URL of the created issue returned by `gh issue create`.
+- With `--json`: `{ "number": number, "url": string }`.
+
+## Examples
+
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type product-backlog --labels "backlog"
+{
+  "title": "User authentication system",
+  "overview": "Implement user authentication to support login and registration flows.",
+  "details": "Use OAuth 2.0 with JWT tokens for session management.",
+  "goal": "Users can sign up, log in, and maintain authenticated sessions.",
+  "notes": "Consider rate limiting for login endpoints."
+}
+EOF
+```
+
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type feature --repo "owner/repo" --labels "feature" --assignees "@me"
+{
+  "title": "Implement login endpoint",
+  "related_urls": "- parent: #42",
+  "goal": "POST /api/login returns a valid JWT token for correct credentials.",
+  "details": "Validate email and password against the user store. Return 401 for invalid credentials."
+}
+EOF
+```

--- a/.config/opencode/skills/gh-ops/references/issue-create-rules.md
+++ b/.config/opencode/skills/gh-ops/references/issue-create-rules.md
@@ -1,64 +1,70 @@
 # Issue Create Rules
 
-## Overview
-
 Create a GitHub Issue with a structured body using one of two templates:
-product-backlog (parent issue) or feature (work item). The script validates input,
-builds the body from the selected template, and creates the issue via gh issue create.
+product-backlog (parent issue) or feature (work item).
 
-Execution order: determine type -> compose content -> confirm with user -> create issue.
-Execute the script from the git repository root, not from the skill directory.
+## Procedure
 
-## Input
+Follow these steps in order. Stop on any failure.
 
-- `type: string` (required): Issue type, passed as `--type`. Must be `product-backlog`
-  or `feature`. See Issue Type Reference below.
-- `repo: string` (optional): Target repository, passed as `--repo OWNER/REPO`. Defaults
-  to the current repository.
-- `labels: string` (optional): Comma-separated labels, passed as `--labels`.
-- `assignees: string` (optional): Comma-separated assignees, passed as `--assignees`.
-- `project: string` (optional): Project name, passed as `--project`.
+### Step 1: Determine Type
 
-Content is provided via stdin JSON:
+Select one based on intent:
+
+- `product-backlog` – Parent issue defining a product goal and its scope. Contains
+  overview, details, goal, and notes sections.
+- `feature` – Work item issue linked to a product backlog. Contains related URLs, goal,
+  and details sections.
+
+Ask the user which type to create. Infer from context when intent is clear.
+
+### Step 2: Compose Content
+
+Prepare title and body fields based on the selected template. See Body Templates below.
+
+Provide content as stdin JSON:
 
 ```json
 {
   "title": "string (required)",
-  "overview": "string (product-backlog)",
+  "overview": "string (product-backlog only)",
   "details": "string",
   "goal": "string",
-  "notes": "string (product-backlog)",
-  "related_urls": "string (feature)"
+  "notes": "string (product-backlog only)",
+  "related_urls": "string (feature only)"
 }
 ```
 
-## Issue Type Reference
+### Step 3: Confirm with User
 
-- product-backlog: Parent issue defining a product goal and its scope. Contains
-  overview, details, goal, and notes sections.
-- feature: Work item issue linked to a product backlog. Contains related URLs, goal,
-  and details sections.
+Present the composed issue content. Proceed only after explicit approval.
 
-## Operations
+### Step 4: Create Issue
 
-### Determine Type
+Required flags:
 
-Ask the user which issue type to create (product-backlog or feature). Infer from
-context when the intent is clear.
+- `--type` – Issue type from Step 1
 
-### Compose Content
+Optional flags:
 
-Prepare title and body fields based on the selected template. See Body Templates below.
+- `--repo OWNER/REPO` – Target repository (defaults to current repository)
+- `--labels` – Comma-separated labels
+- `--assignees` – Comma-separated assignees
+- `--project` – Project name
 
-### Confirm with User
+Recommended JSON fields per type:
 
-Present the composed issue content to the user and get explicit approval before
-creating. Do not create without that confirmation.
+- `product-backlog`: `title` (required), `overview`, `details`, `goal`, `notes`
+- `feature`: `title` (required), `related_urls`, `goal`, `details`
 
-### Create Issue
-
-Run `bash scripts/create-issue.sh` with `--type` and optional metadata flags. Pipe
-the composed JSON payload through stdin.
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type <type> [optional flags]
+{
+  "title": "...",
+  ...
+}
+EOF
+```
 
 The script validates the JSON, builds the body from the template, and creates the
 issue via `gh issue create`. On success it prints the issue URL to stdout.
@@ -111,7 +117,7 @@ Sections with empty content include only the header.
 
 ## Output
 
-- `url: string`: URL of the created issue returned by `gh issue create`.
+- `url: string`: URL of the created issue printed to stdout by the script.
 - With `--json`: `{ "number": number, "url": string }`.
 
 ## Examples

--- a/.config/opencode/skills/gh-ops/references/pr-create-rules.md
+++ b/.config/opencode/skills/gh-ops/references/pr-create-rules.md
@@ -1,49 +1,80 @@
 # PR Create Rules
 
-## Overview
+Create a draft pull request with a Conventional Commits-style title and
+standardized body.
 
-Create a draft pull request on GitHub with a Conventional Commits-style title and a
-standardized body, using the shipped shell scripts.
+## Procedure
 
-Execute all scripts from the target git repository root, never from the skill directory.
-Use only the shipped scripts; do not run extra git or gh commands. Title must be natural
-language in imperative mood with no trailing period and no file paths. Title and body
-default to English unless the user explicitly requests another language.
+Follow these steps in order. Stop on any failure.
 
-## Operations
+### Step 1: Check Branch Status
 
-### Check Branch Status
+Run `bash scripts/check-branch-status.sh [--base <branch>]`.
+Inspects uncommitted changes, commit history, and diff statistics.
+Abort if no commits differ from the base branch.
 
-Run `bash scripts/check-branch-status.sh [--base <branch>]` to inspect uncommitted
-changes, commit history, and diff statistics. Abort if the branch has no commits
-differing from the base.
+### Step 2: Determine PR Type
 
-### Create Draft PR
+Select one based on the changes:
 
-Choose type from the PR Type Reference below, write a title and change bullets, then
-run `bash scripts/create-pr.sh` with accepted flags. Pass `--changes` as bullet lines
-starting with `-`. The script validates type and required parameters; abort on
-validation errors.
+- `build` – Build system or external dependency changes
+- `chore` – Maintenance tasks, scripts, config
+- `ci` – CI configuration and scripts
+- `docs` – Documentation changes
+- `feat` – New features
+- `fix` – Bug fixes
+- `i18n` – Internationalization
+- `perf` – Performance improvements
+- `refactor` – Code refactoring
+- `revert` – Revert previous commits
+- `style` – Code style changes (formatting, whitespace)
+- `test` – Test additions or corrections
 
-Accepted flags: `--type`, `--title`, `--changes`, `--related-urls`, `--confirmation`,
-`--review-points`, `--limitations`, `--additional`, `--base`.
+### Step 3: Compose Title
 
-## PR Type Reference
+Format: imperative mood, concise, no trailing period, no file paths.
 
-| Type     | Description                                 |
-| -------- | ------------------------------------------- |
-| build    | Build system or external dependency changes |
-| chore    | Maintenance tasks, scripts, config          |
-| ci       | CI configuration and scripts                |
-| docs     | Documentation changes                       |
-| feat     | New features                                |
-| fix      | Bug fixes                                   |
-| perf     | Performance improvements                    |
-| refactor | Code refactoring                            |
-| revert   | Revert previous commits                     |
-| style    | Code style changes (formatting, whitespace) |
-| test     | Test additions or corrections               |
-| i18n     | Internationalization                        |
+- Good: `"clarify PR draft skill"`, `"resolve token expiration"`
+- Bad: `"clarified the PR draft skill."`, `"update src/auth/token.ts"`
+
+### Step 4: Compose Body Content
+
+Required flags:
+
+- `--type` – PR type from Step 2
+- `--title` – Title from Step 3
+- `--changes` – Bullet lines starting with `-`
+
+Optional flags:
+
+- `--related-urls` – Related issue/PR URLs
+- `--confirmation` – Verification steps performed
+- `--review-points` – Areas needing reviewer attention
+- `--limitations` – Known limitations or follow-up needed
+- `--additional` – Any extra context
+- `--base` – Base branch (default: repo default branch)
+
+### Step 5: Confirm with User
+
+Present the composed title, type, and body content. Proceed only after explicit
+approval.
+
+### Step 6: Create Draft PR
+
+```bash
+bash scripts/create-pr.sh \
+  --type <type> \
+  --title "<title>" \
+  --changes "<bullet lines>" \
+  [--related-urls "<urls>"] \
+  [--confirmation "<results>"] \
+  [--review-points "<points>"] \
+  [--limitations "<limitations>"] \
+  [--additional "<context>"] \
+  [--base <branch>]
+```
+
+The script validates type and required parameters. Abort on validation errors.
 
 ## PR Body Format
 
@@ -73,6 +104,8 @@ Accepted flags: `--type`, `--title`, `--changes`, `--related-urls`, `--confirmat
 
 ## Examples
 
+Minimal:
+
 ```bash
 bash scripts/check-branch-status.sh --base main
 bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
@@ -81,6 +114,8 @@ bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
 - extract the PR body template" \
   --base main
 ```
+
+Full:
 
 ```bash
 bash scripts/check-branch-status.sh

--- a/.config/opencode/skills/gh-ops/references/pr-create-rules.md
+++ b/.config/opencode/skills/gh-ops/references/pr-create-rules.md
@@ -1,0 +1,93 @@
+# PR Create Rules
+
+## Overview
+
+Create a draft pull request on GitHub with a Conventional Commits-style title and a
+standardized body, using the shipped shell scripts.
+
+Execute all scripts from the target git repository root, never from the skill directory.
+Use only the shipped scripts; do not run extra git or gh commands. Title must be natural
+language in imperative mood with no trailing period and no file paths. Title and body
+default to English unless the user explicitly requests another language.
+
+## Operations
+
+### Check Branch Status
+
+Run `bash scripts/check-branch-status.sh [--base <branch>]` to inspect uncommitted
+changes, commit history, and diff statistics. Abort if the branch has no commits
+differing from the base.
+
+### Create Draft PR
+
+Choose type from the PR Type Reference below, write a title and change bullets, then
+run `bash scripts/create-pr.sh` with accepted flags. Pass `--changes` as bullet lines
+starting with `-`. The script validates type and required parameters; abort on
+validation errors.
+
+Accepted flags: `--type`, `--title`, `--changes`, `--related-urls`, `--confirmation`,
+`--review-points`, `--limitations`, `--additional`, `--base`.
+
+## PR Type Reference
+
+| Type     | Description                                 |
+| -------- | ------------------------------------------- |
+| build    | Build system or external dependency changes |
+| chore    | Maintenance tasks, scripts, config          |
+| ci       | CI configuration and scripts                |
+| docs     | Documentation changes                       |
+| feat     | New features                                |
+| fix      | Bug fixes                                   |
+| perf     | Performance improvements                    |
+| refactor | Code refactoring                            |
+| revert   | Revert previous commits                     |
+| style    | Code style changes (formatting, whitespace) |
+| test     | Test additions or corrections               |
+| i18n     | Internationalization                        |
+
+## PR Body Format
+
+```markdown
+## Related URLs
+
+{related_urls}
+
+## Changes
+
+{changes}
+
+## Confirmation Results
+
+{confirmation_results}
+
+## Review Points
+
+{review_points}
+
+## Limitations
+
+{limitations}
+
+{additional}
+```
+
+## Examples
+
+```bash
+bash scripts/check-branch-status.sh --base main
+bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
+  --changes "- rewrite the skill overview
+- extract the type reference
+- extract the PR body template" \
+  --base main
+```
+
+```bash
+bash scripts/check-branch-status.sh
+bash scripts/create-pr.sh --type fix --title "resolve token expiration" \
+  --changes "- update token refresh logic
+- add proper error handling for expired tokens" \
+  --confirmation "- tested token refresh flow" \
+  --review-points "- token refresh timing" \
+  --limitations "- requires frontend update for new error codes"
+```

--- a/.config/opencode/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/opencode/skills/gh-ops/references/pr-review-rules.md
@@ -1,39 +1,68 @@
 # PR Review Rules
 
-## Overview
+Create a pending review on a GitHub PR with inline comments via
+`scripts/create_review.sh`.
 
-Run `scripts/create_review.sh` to create a pending review on a GitHub PR. The
-script accepts repository coordinates, a PR number, and a JSON array of inline
-comments as CLI arguments. It validates inputs, calls the GitHub API via `gh`,
-and prints a JSON result to stdout.
+## Procedure
 
-Invoke only `scripts/create_review.sh`; do not call the GitHub API directly.
-Pass all inputs as CLI arguments; do not use environment variables for review data.
+Follow these steps in order. Stop on any failure.
+
+### Step 1: Compose Comments
+
+Prepare inline comments for the review. Each comment requires:
+
+- `path: string` – File path relative to the repository root
+- `line: number` – Line number to attach the comment to
+- `body: string` – Comment body text
+
+Optional per comment:
+
+- `suggestion: string` – Code suggestion content. Do not include triple backticks;
+  the script wraps it in a GitHub suggestion block automatically.
+- `start_line: number` – Start line for multi-line comments
+- `side: "LEFT" | "RIGHT"` – Diff side
+
 Provide `--comments-json` as a valid JSON array with at least one element.
-Include `path`, `line`, and `body` for every comment object.
-Keep suggestion text free of triple backticks because the script wraps suggestions
-in a fenced suggestion block.
-Treat created reviews as pending drafts; submit them manually via the GitHub UI.
 
-## Input
+### Step 2: Confirm with User
 
-- `--owner` (required): Repository owner.
-- `--repo` (required): Repository name.
-- `--pull-number` (required): PR number.
-- `--comments-json` (required): JSON array of comment objects. Each object requires:
-  - `path: string` — File path relative to the repository root.
-  - `line: number` — Line number to attach the comment to.
-  - `body: string` — Comment body text.
-  - `suggestion: string` (optional) — Code suggestion content. The script wraps it
-    in a GitHub suggestion block.
-  - `start_line: number` (optional) — Start line for multi-line comments.
-  - `side: "LEFT" | "RIGHT"` (optional) — Diff side.
-- `--summary-body` (optional): Review summary body text.
+Present the composed comments and summary. Proceed only after explicit approval.
 
-## Output
+### Step 3: Create Review
+
+Required flags:
+
+- `--owner` – Repository owner
+- `--repo` – Repository name
+- `--pull-number` – PR number
+- `--comments-json` – JSON array of comment objects (at least one element required)
+
+Optional flags:
+
+- `--summary-body` – Review summary body text
+
+```bash
+bash scripts/create_review.sh \
+  --owner "<owner>" \
+  --repo "<repo>" \
+  --pull-number <number> \
+  --comments-json '<json array>' \
+  [--summary-body "<text>"]
+```
 
 On success, stdout contains `{ "id": {number}, "html_url": "{url}" }`.
 On failure, stderr contains an error message and the script exits non-zero.
+
+### Step 4: Do Not Submit the Review
+
+The review is created as a pending draft. Do not submit it via the CLI.
+The user will submit it manually via the GitHub UI when ready.
+
+## Output
+
+On success: `{ "id": {number}, "html_url": "{url}" }`
+
+On failure: error message on stderr, non-zero exit code.
 
 ## Examples
 

--- a/.config/opencode/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/opencode/skills/gh-ops/references/pr-review-rules.md
@@ -1,0 +1,46 @@
+# PR Review Rules
+
+## Overview
+
+Run `scripts/create_review.sh` to create a pending review on a GitHub PR. The
+script accepts repository coordinates, a PR number, and a JSON array of inline
+comments as CLI arguments. It validates inputs, calls the GitHub API via `gh`,
+and prints a JSON result to stdout.
+
+Invoke only `scripts/create_review.sh`; do not call the GitHub API directly.
+Pass all inputs as CLI arguments; do not use environment variables for review data.
+Provide `--comments-json` as a valid JSON array with at least one element.
+Include `path`, `line`, and `body` for every comment object.
+Keep suggestion text free of triple backticks because the script wraps suggestions
+in a fenced suggestion block.
+Treat created reviews as pending drafts; submit them manually via the GitHub UI.
+
+## Input
+
+- `--owner` (required): Repository owner.
+- `--repo` (required): Repository name.
+- `--pull-number` (required): PR number.
+- `--comments-json` (required): JSON array of comment objects. Each object requires:
+  - `path: string` — File path relative to the repository root.
+  - `line: number` — Line number to attach the comment to.
+  - `body: string` — Comment body text.
+  - `suggestion: string` (optional) — Code suggestion content. The script wraps it
+    in a GitHub suggestion block.
+  - `start_line: number` (optional) — Start line for multi-line comments.
+  - `side: "LEFT" | "RIGHT"` (optional) — Diff side.
+- `--summary-body` (optional): Review summary body text.
+
+## Output
+
+On success, stdout contains `{ "id": {number}, "html_url": "{url}" }`.
+On failure, stderr contains an error message and the script exits non-zero.
+
+## Examples
+
+```bash
+bash scripts/create_review.sh \
+  --owner "myorg" \
+  --repo "myrepo" \
+  --pull-number 42 \
+  --comments-json '[{"path":"src/auth.py","line":42,"body":"Add null check here"}]'
+```

--- a/.config/opencode/skills/gh-ops/scripts/check-branch-status.sh
+++ b/.config/opencode/skills/gh-ops/scripts/check-branch-status.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Parse arguments
+BASE_BRANCH_ARG=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base)
+      BASE_BRANCH_ARG="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Usage: $0 [--base <branch>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Get current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Determine base branch
+if [[ -n "$BASE_BRANCH_ARG" ]]; then
+  BASE_BRANCH="$BASE_BRANCH_ARG"
+else
+  # Get remote HEAD branch (what origin points to as default)
+  REMOTE_HEAD_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+  if [[ -z "$REMOTE_HEAD_BRANCH" ]]; then
+    REMOTE_HEAD_BRANCH="main"
+  fi
+  BASE_BRANCH="$REMOTE_HEAD_BRANCH"
+fi
+
+echo "=== Repository Information ==="
+echo "Current branch: $CURRENT_BRANCH"
+if [[ -z "$BASE_BRANCH_ARG" ]]; then
+  echo "Remote HEAD branch: $BASE_BRANCH"
+fi
+echo "Base branch for comparison: $BASE_BRANCH"
+if [[ -z "$BASE_BRANCH_ARG" ]]; then
+  echo ""
+  echo "Note: 'gh pr create' will automatically determine the base branch"
+  echo "      based on the branch configuration and remote tracking."
+fi
+
+echo
+echo "=== Uncommitted changes ==="
+git status --short
+
+echo
+echo "=== Commit history (comparing with base: $BASE_BRANCH) ==="
+git log "$BASE_BRANCH..HEAD" --oneline || echo "No commits ahead of $BASE_BRANCH"
+
+echo
+echo "=== Diff statistics (from merge base with base branch) ==="
+git diff "$BASE_BRANCH...HEAD" --stat || echo "No differences from $BASE_BRANCH"

--- a/.config/opencode/skills/gh-ops/scripts/create-issue.sh
+++ b/.config/opencode/skills/gh-ops/scripts/create-issue.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: print_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  printf '%s\n' "$1" >&2
+}
+
+usage_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: usage_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r allowed_params='--type TYPE [--repo OWNER/REPO] [--labels L1,L2] [--assignees A1,A2] [--project NAME] [--json] [--dry-run]'
+
+  print_error "Error: $1"
+  print_error "Allowed parameters: $allowed_params"
+  exit 1
+}
+
+validate_input_json() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: validate_input_json expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r input_json="$1"
+  local -r validation_filter="$(
+    cat <<'JQ'
+def fail(message): message | halt_error(1);
+def require_non_empty_string(field_name):
+  if type != "string" or length == 0 then
+    fail(field_name + " must be a non-empty string")
+  else
+    .
+  end;
+def optional_string(field_name):
+  if . == null then
+    ""
+  elif type != "string" then
+    fail(field_name + " must be a string when provided")
+  else
+    .
+  end;
+
+if type != "object" then
+  fail("input must be a JSON object")
+else
+  .
+end
+| {
+    title: (.title | require_non_empty_string("title")),
+    overview: (.overview | optional_string("overview")),
+    details: (.details | optional_string("details")),
+    goal: (.goal | optional_string("goal")),
+    notes: (.notes | optional_string("notes")),
+    related_urls: (.related_urls | optional_string("related_urls"))
+  }
+JQ
+  )"
+  local validated_json
+  local error_file
+  error_file="$(mktemp)"
+
+  if validated_json="$(printf '%s' "$input_json" | jq -ce "$validation_filter" 2>"$error_file")"; then
+    rm -f -- "$error_file"
+    printf '%s' "$validated_json"
+    return 0
+  fi
+
+  local validation_error
+  validation_error="$(cat "$error_file")"
+  rm -f -- "$error_file"
+  validation_error="$(printf '%s' "$validation_error" | tr '\n' ' ' | sed -E \
+    -e 's/^jq: error \(at <stdin>:[0-9]+\): //' \
+    -e 's/^parse error: /invalid JSON: /' \
+    -e 's/[[:space:]]+$//')"
+
+  if [[ -z "$validation_error" ]]; then
+    print_error 'Error: invalid input JSON'
+  else
+    print_error "Error: $validation_error"
+  fi
+
+  return 1
+}
+
+build_body() {
+  if [[ $# -ne 2 ]]; then
+    printf '%s\n' 'Error: build_body expects exactly 2 arguments' >&2
+    return 1
+  fi
+
+  local -r validated_json="$1"
+  local -r issue_type="$2"
+  local -r body_filter="$(
+    cat <<'JQ'
+def section(header; content):
+  if content | length > 0 then
+    "## " + header + "\n\n" + content
+  else
+    "## " + header
+  end;
+
+if $type == "product-backlog" then
+  [
+    section("Overview"; .overview),
+    section("Details"; .details),
+    section("Goal"; .goal),
+    section("Notes"; .notes)
+  ] | join("\n\n")
+elif $type == "feature" then
+  [
+    section("Related URLs"; .related_urls),
+    section("Goal"; .goal),
+    section("Details"; .details)
+  ] | join("\n\n")
+else
+  "unknown type: " + $type | halt_error(1)
+end
+JQ
+  )"
+
+  printf '%s' "$validated_json" | jq -r --arg type "$issue_type" "$body_filter"
+}
+
+check_dependencies() {
+  type jq >/dev/null 2>&1 || {
+    print_error 'Error: jq is required but not found'
+    exit 1
+  }
+  type gh >/dev/null 2>&1 || {
+    print_error 'Error: gh is required but not found'
+    exit 1
+  }
+}
+
+main() {
+  check_dependencies
+
+  local issue_type=""
+  local repo=""
+  local labels=""
+  local assignees=""
+  local project=""
+  local json_output=false
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --type)
+        [[ $# -ge 2 ]] || usage_error '--type requires a value'
+        issue_type="$2"
+        shift 2
+        ;;
+      --repo)
+        [[ $# -ge 2 ]] || usage_error '--repo requires a value'
+        repo="$2"
+        shift 2
+        ;;
+      --labels)
+        [[ $# -ge 2 ]] || usage_error '--labels requires a value'
+        labels="$2"
+        shift 2
+        ;;
+      --assignees)
+        [[ $# -ge 2 ]] || usage_error '--assignees requires a value'
+        assignees="$2"
+        shift 2
+        ;;
+      --project)
+        [[ $# -ge 2 ]] || usage_error '--project requires a value'
+        project="$2"
+        shift 2
+        ;;
+      --json)
+        json_output=true
+        shift
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      *)
+        usage_error "unknown parameter: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$issue_type" ]] || usage_error '--type is required'
+  [[ "$issue_type" == "product-backlog" || "$issue_type" == "feature" ]] ||
+    usage_error '--type must be product-backlog or feature'
+  if [[ -n "$repo" ]]; then
+    [[ "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]] ||
+      usage_error '--repo must be in OWNER/REPO format'
+  fi
+
+  local input_json
+  input_json="$(cat)"
+
+  local validated_json
+  validated_json="$(validate_input_json "$input_json")"
+
+  local title
+  title="$(printf '%s' "$validated_json" | jq -r '.title')"
+
+  local body
+  body="$(build_body "$validated_json" "$issue_type")"
+
+  if [[ "$dry_run" == true ]]; then
+    printf '%s\n' '=== Preview (dry-run) ==='
+    printf '%s\n' "Type: $issue_type"
+    printf '%s\n' "Title: $title"
+    [[ -n "$repo" ]] && printf '%s\n' "Repo: $repo"
+    [[ -n "$labels" ]] && printf '%s\n' "Labels: $labels"
+    [[ -n "$assignees" ]] && printf '%s\n' "Assignees: $assignees"
+    [[ -n "$project" ]] && printf '%s\n' "Project: $project"
+    printf '%s\n' '=== Body ==='
+    printf '%s\n' "$body"
+    exit 0
+  fi
+
+  local -a gh_args=()
+  gh_args+=(--title "$title")
+  gh_args+=(--body-file -)
+
+  if [[ -n "$repo" ]]; then
+    gh_args+=(--repo "$repo")
+  fi
+
+  if [[ -n "$labels" ]]; then
+    local IFS=','
+    local -a label_array
+    read -ra label_array <<<"$labels"
+    local label
+    for label in "${label_array[@]}"; do
+      gh_args+=(--label "$label")
+    done
+  fi
+
+  if [[ -n "$assignees" ]]; then
+    local IFS=','
+    local -a assignee_array
+    read -ra assignee_array <<<"$assignees"
+    local assignee
+    for assignee in "${assignee_array[@]}"; do
+      gh_args+=(--assignee "$assignee")
+    done
+  fi
+
+  if [[ -n "$project" ]]; then
+    gh_args+=(--project "$project")
+  fi
+
+  local url
+  url="$(printf '%s\n' "$body" | gh issue create "${gh_args[@]}")"
+
+  if [[ "$json_output" == true ]]; then
+    local number
+    number="$(printf '%s' "$url" | grep -oE '[0-9]+$')"
+    printf '{"number":%s,"url":"%s"}\n' "$number" "$url"
+  else
+    printf '%s\n' "$url"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/opencode/skills/gh-ops/scripts/create-pr.sh
+++ b/.config/opencode/skills/gh-ops/scripts/create-pr.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Verify we're in a git repository
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Error: Not in a git repository" >&2
+  echo "Please run this script from within a git repository" >&2
+  exit 1
+fi
+
+# Allowed PR types
+ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n)
+
+# Initialize variables
+TYPE=""
+TITLE=""
+RELATED_URLS=""
+CHANGES=""
+CONFIRMATION=""
+REVIEW_POINTS=""
+LIMITATIONS=""
+ADDITIONAL=""
+BASE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    --title)
+      TITLE="$2"
+      shift 2
+      ;;
+    --related-urls)
+      RELATED_URLS="$2"
+      shift 2
+      ;;
+    --changes)
+      CHANGES="$2"
+      shift 2
+      ;;
+    --confirmation)
+      CONFIRMATION="$2"
+      shift 2
+      ;;
+    --review-points)
+      REVIEW_POINTS="$2"
+      shift 2
+      ;;
+    --limitations)
+      LIMITATIONS="$2"
+      shift 2
+      ;;
+    --additional)
+      ADDITIONAL="$2"
+      shift 2
+      ;;
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Allowed parameters: --type, --title, --related-urls, --changes, --confirmation, --review-points, --limitations, --additional, --base" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required parameters
+if [[ -z "$TYPE" ]]; then
+  echo "Error: --type is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TITLE" ]]; then
+  echo "Error: --title is required" >&2
+  exit 1
+fi
+
+if [[ -z "$CHANGES" ]]; then
+  echo "Error: --changes is required" >&2
+  exit 1
+fi
+
+# Validate type
+if [[ ! " ${ALLOWED_TYPES[*]} " =~ ${TYPE} ]]; then
+  echo "Error: Invalid type '$TYPE'" >&2
+  echo "Allowed types: ${ALLOWED_TYPES[*]}" >&2
+  exit 1
+fi
+
+# Build PR title: <type>: <title>
+PR_TITLE="${TYPE}: ${TITLE}"
+
+# Build PR body
+PR_BODY="## Related URLs"
+if [[ -n "$RELATED_URLS" ]]; then
+  PR_BODY="${PR_BODY}
+${RELATED_URLS}"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Changes
+${CHANGES}
+
+## Confirmation Results"
+if [[ -n "$CONFIRMATION" ]]; then
+  PR_BODY="${PR_BODY}
+${CONFIRMATION}"
+else
+  PR_BODY="${PR_BODY}
+
+<!-- Describe preconditions, steps, and results of confirmation if any -->"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Review Points"
+if [[ -n "$REVIEW_POINTS" ]]; then
+  PR_BODY="${PR_BODY}
+${REVIEW_POINTS}"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Limitations"
+if [[ -n "$LIMITATIONS" ]]; then
+  PR_BODY="${PR_BODY}
+${LIMITATIONS}"
+else
+  PR_BODY="${PR_BODY}
+
+<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->"
+fi
+
+if [[ -n "$ADDITIONAL" ]]; then
+  PR_BODY="${PR_BODY}
+
+${ADDITIONAL}"
+fi
+
+# Execute gh pr create
+if [[ -n "$BASE" ]]; then
+  gh pr create --draft --base "$BASE" --title "$PR_TITLE" --body "$PR_BODY"
+else
+  gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY"
+fi

--- a/.config/opencode/skills/gh-ops/scripts/create_review.py
+++ b/.config/opencode/skills/gh-ops/scripts/create_review.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+__all__ = ["main"]
+
+
+@dataclass(frozen=True)
+class ReviewResult:
+    id: int
+    html_url: str
+
+    def to_json(self) -> str:
+        return json.dumps({"id": self.id, "html_url": self.html_url})
+
+
+def extract_http_status(stderr_text: str) -> int | None:
+    match = re.search(r"HTTP\s+(\d{3})", stderr_text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def emit_error(message: str, *, exit_code: int = 1, **details: Any) -> NoReturn:
+    error_payload = {"error": message, **details}
+    print(json.dumps(error_payload), file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def main() -> None:
+    """
+    Parses arguments, constructs a JSON payload, and calls the GitHub API
+    to create a pending review.
+    """
+    parser = argparse.ArgumentParser(description="Create a pending PR review.")
+    parser.add_argument("--owner", required=True, help="Repository owner")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--pull-number", required=True, type=int, help="PR number")
+    parser.add_argument("--summary-body", required=True, help="Review summary body")
+    parser.add_argument("--comments-json", required=True, help="JSON string of comments array")
+
+    args = parser.parse_args()
+
+    try:
+        raw_comments = json.loads(args.comments_json)
+    except json.JSONDecodeError as e:
+        emit_error("invalid_comments_json", detail=f"Invalid JSON in --comments-json: {e}")
+
+    if not isinstance(raw_comments, list):
+        emit_error("invalid_comments_json", detail="--comments-json must be a JSON array")
+
+    api_comments = []
+    for index, comment in enumerate(raw_comments):
+        if not isinstance(comment, dict):
+            emit_error(
+                "invalid_comment",
+                detail=f"Comment at index {index} must be an object",
+            )
+
+        body = comment.get("body", "")
+        suggestion = comment.get("suggestion")
+        path = comment.get("path")
+        line = comment.get("line")
+        start_line = comment.get("start_line")
+        side = comment.get("side", "RIGHT")
+
+        if not path or line is None:
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} is missing required path or line",
+            )
+
+        # Append suggestion block if present
+        if suggestion:
+            if "```" in suggestion:
+                emit_error(
+                    "invalid_suggestion_content",
+                    detail=(
+                        f"Comment at index {index} suggestion must not contain triple backticks"
+                    ),
+                )
+            suggestion_block = f"\n\n```suggestion\n{suggestion}\n```"
+            body += suggestion_block
+
+        try:
+            parsed_line = int(line)
+        except (TypeError, ValueError):
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} has non-integer line: {line}",
+            )
+
+        # Construct API comment object
+        api_comment = {"path": path, "body": body, "line": parsed_line, "side": side}
+
+        if start_line:
+            try:
+                api_comment["start_line"] = int(start_line)
+            except (TypeError, ValueError):
+                emit_error(
+                    "invalid_comment_location",
+                    detail=(f"Comment at index {index} has non-integer start_line: {start_line}"),
+                )
+
+        api_comments.append(api_comment)
+
+    # Construct payload for GitHub API
+    payload = {"body": args.summary_body, "comments": api_comments}
+    # event is OMITTED to create a PENDING review
+
+    # Call gh api
+    endpoint = f"repos/{args.owner}/{args.repo}/pulls/{args.pull_number}/reviews"
+    json_payload = json.dumps(payload)
+
+    cmd = ["gh", "api", endpoint, "--method", "POST", "--input", "-"]
+
+    result = subprocess.run(cmd, input=json_payload, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        emit_error(
+            "gh_api_failed",
+            detail="Failed to create pending review via gh api",
+            exit_code=1,
+            gh_exit_code=result.returncode,
+            http_status=extract_http_status(result.stderr),
+            stderr=result.stderr.strip(),
+        )
+
+    try:
+        response_data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        emit_error(
+            "invalid_api_response",
+            detail=f"Failed to parse gh api response as JSON: {error}",
+            stdout=result.stdout.strip(),
+        )
+
+    review_id = response_data.get("id")
+    html_url = response_data.get("html_url")
+    if not isinstance(review_id, int) or not isinstance(html_url, str):
+        emit_error(
+            "invalid_api_response",
+            detail="API response missing required id or html_url fields",
+            response=response_data,
+        )
+
+    print(ReviewResult(id=review_id, html_url=html_url).to_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/opencode/skills/gh-ops/scripts/create_review.sh
+++ b/.config/opencode/skills/gh-ops/scripts/create_review.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the directory of this script
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! type python3 >/dev/null 2>&1; then
+  printf '%s\n' "Error: python3 is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! type gh >/dev/null 2>&1; then
+  printf '%s\n' "Error: gh is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf '%s\n' "Error: GitHub CLI is not authenticated. Run 'gh auth login' and try again." >&2
+  exit 1
+fi
+
+# Call the Python script with all arguments
+python3 "$SCRIPT_DIR/create_review.py" "$@"

--- a/.config/opencode/skills/gh-ops/scripts/post-comment.sh
+++ b/.config/opencode/skills/gh-ops/scripts/post-comment.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: print_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  printf '%s\n' "$1" >&2
+}
+
+usage_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: usage_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r allowed_params='--repo OWNER/REPO --issue NUMBER [--dry-run]'
+
+  print_error "Error: $1"
+  print_error "Allowed parameters: $allowed_params"
+  exit 1
+}
+
+validate_input_json() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: validate_input_json expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r input_json="$1"
+  local -r validation_filter="$(
+    cat <<'JQ'
+def fail(message): message | halt_error(1);
+def require_non_empty_string(field_name):
+  if type != "string" or length == 0 then
+    fail(field_name + " must be a non-empty string")
+  else
+    .
+  end;
+def validate_detail:
+  if type != "object" then
+    fail("details[] must be objects")
+  else
+    .
+  end
+  | {
+      label: (.label | require_non_empty_string("details[].label")),
+      content: (.content | require_non_empty_string("details[].content"))
+    }
+  | if (.label | test("[<>]")) then
+      fail("details[].label must not contain < or >")
+    else
+      .
+    end;
+
+if type != "object" then
+  fail("input must be a JSON object")
+else
+  .
+end
+| {
+    summary: (.summary | require_non_empty_string("summary")),
+    details: (
+      if .details == null then
+        []
+      elif (.details | type) != "array" then
+        fail("details must be an array when provided")
+      else
+        .details | map(validate_detail)
+      end
+    )
+  }
+JQ
+  )"
+  local validated_json
+  local validation_error
+
+  local error_file
+  error_file="$(mktemp)"
+  trap "rm -f -- '$error_file'" EXIT
+
+  if validated_json="$(printf '%s' "$input_json" | jq -ce "$validation_filter" 2>"$error_file")"; then
+    rm -f "$error_file"
+    printf '%s' "$validated_json"
+    return 0
+  fi
+
+  validation_error="$(cat "$error_file")"
+  rm -f "$error_file"
+  # Clean up jq-specific prefixes for friendlier messages (raw text used as fallback)
+  validation_error="$(printf '%s' "$validation_error" | tr '\n' ' ' | sed -E \
+    -e 's/^jq: error \(at <stdin>:[0-9]+\): //' \
+    -e 's/^parse error: /invalid JSON: /' \
+    -e 's/[[:space:]]+$//')"
+
+  if [[ -z "$validation_error" ]]; then
+    print_error 'Error: invalid input JSON'
+  else
+    print_error "Error: $validation_error"
+  fi
+
+  return 1
+}
+
+build_body() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: build_body expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r validated_json="$1"
+  local -r body_filter="$(
+    cat <<'JQ'
+.summary + (
+  .details
+  | map("\n\n<details>\n<summary>\(.label)</summary>\n\n\(.content)\n\n</details>")
+  | join("")
+)
+JQ
+  )"
+
+  printf '%s' "$validated_json" | jq -r "$body_filter"
+}
+
+check_dependencies() {
+  type jq >/dev/null 2>&1 || {
+    print_error 'Error: jq is required but not found'
+    exit 1
+  }
+}
+
+main() {
+  check_dependencies
+
+  local repo=""
+  local issue=""
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        [[ $# -ge 2 ]] || usage_error '--repo requires a value'
+        repo="$2"
+        shift 2
+        ;;
+      --issue)
+        [[ $# -ge 2 ]] || usage_error '--issue requires a value'
+        issue="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      *)
+        usage_error "unknown parameter: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$repo" ]] || usage_error '--repo is required'
+  [[ "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]] || usage_error '--repo must be in OWNER/REPO format'
+  [[ -n "$issue" ]] || usage_error '--issue is required'
+  [[ "$issue" =~ ^[0-9]+$ ]] || usage_error '--issue must be a number'
+
+  local input_json
+  input_json="$(cat)"
+
+  local validated_json
+  validated_json="$(validate_input_json "$input_json")"
+
+  local body
+  body="$(build_body "$validated_json")"
+
+  if [[ "$dry_run" == true ]]; then
+    printf '%s\n' '=== Preview (dry-run) ==='
+    printf '%s\n' "Target: $repo#$issue"
+    printf '%s\n' '=== Body ==='
+    printf '%s\n' "$body"
+    exit 0
+  fi
+
+  printf '%s\n' "$body" | gh issue comment "$issue" --repo "$repo" --body-file -
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/opencode/skills/git-commit/SKILL.md
+++ b/.config/opencode/skills/git-commit/SKILL.md
@@ -1,48 +1,58 @@
 ---
 name: git-commit
-description: Conventional Commits-compliant git commit execution logic.
+description: >
+  Create a git commit from current changes.
+  Trigger on commit requests or after completing a code change task.
 ---
 
 # Git Commit
 
 ## Overview
 
-Execute a Conventional Commits 1.0.0-compliant git commit, automatically deriving
-type and message from the current working tree or staged state. If no files are staged,
-stage all changes before committing.
+Analyze the current working tree, derive a Conventional Commits 1.0.0-compliant
+message, and commit. Always execute from the git repository root.
 
-Execute all scripts from the git repository root, not from the skill directory.
+## Process
 
-## Output
+### 1. Stage
 
-- `sha: string`: The commit SHA created by the commit script.
-- `message: string`: The full commit message.
+1. Run `git diff --staged --name-only`.
+2. If nothing staged, selectively stage only files related to the current task.
+3. If still nothing staged, abort: "no changes to commit".
 
-## Operations
+### 2. Analyze
 
-### Prepare Staged Changes
+1. Collect diff: `git --no-pager diff --staged`.
+2. Derive type from [`references/types.md`](references/types.md).
+3. Write description: imperative English, no trailing period, ≤100 chars including type prefix.
+4. Optionally add body with `-` bullet lines.
 
-Run `git diff --staged --name-only` to detect staged files.
+### 3. Commit
 
-- If files are already staged, skip to collecting the diff.
-- If nothing is staged, run `git add -A` to stage all changes.
-- If still nothing is staged after `git add -A`, abort with "no changes to commit".
+Run [`scripts/commit.sh`](scripts/commit.sh) with the following options.
+Do NOT read the script; use it as a black box.
 
-Collect the staged file list with `git diff --staged --name-only` and the full diff with
-`git --no-pager diff --staged`.
+- `--type <string>` (required): Commit type derived from step 2
+- `--description <string>` (required): Commit description derived from step 2
+- `--body <string>` (optional): Body text, may contain newlines
+- `--json` (required): Flag. Enables JSON output (`sha`, `message`) to stdout
 
-### Analyze Diff
+Example:
 
-Derive the commit type from [`references/types.md`](references/types.md) and write a
-natural-language description summarizing what changed and why. The description must be
-imperative English, have no trailing period, and fit within 100 characters including the
-type prefix. Abort if the description is empty or is a file path instead of natural language.
-Optionally produce a body with bullet lines each starting with `-`.
+```bash
+scripts/commit.sh \
+  --type feat \
+  --description "add user authentication endpoint" \
+  --body "- add POST /auth/login route
+- implement JWT token generation
+- add input validation middleware" \
+  --json
+```
 
-### Commit
+Return the JSON output as the final result.
 
-Run [`scripts/commit.sh`](scripts/commit.sh) with `--type`, `--description`, and
-optionally `--body`, plus `--json` for structured output. Abort if the type is not listed
-in [`references/types.md`](references/types.md) or if git commit fails.
+## Constraints
 
-Return the JSON output from commit.sh as the final result.
+- Abort if description is empty or is a file path.
+- Abort if type is not in [`references/types.md`](references/types.md).
+- Abort if git commit fails.

--- a/.config/opencode/skills/git-commit/SKILL.md
+++ b/.config/opencode/skills/git-commit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: git-commit
+description: Conventional Commits-compliant git commit execution logic.
+---
+
+# Git Commit
+
+## Overview
+
+Execute a Conventional Commits 1.0.0-compliant git commit, automatically deriving
+type and message from the current working tree or staged state. If no files are staged,
+stage all changes before committing.
+
+Execute all scripts from the git repository root, not from the skill directory.
+
+## Output
+
+- `sha: string`: The commit SHA created by the commit script.
+- `message: string`: The full commit message.
+
+## Operations
+
+### Prepare Staged Changes
+
+Run `git diff --staged --name-only` to detect staged files.
+
+- If files are already staged, skip to collecting the diff.
+- If nothing is staged, run `git add -A` to stage all changes.
+- If still nothing is staged after `git add -A`, abort with "no changes to commit".
+
+Collect the staged file list with `git diff --staged --name-only` and the full diff with
+`git --no-pager diff --staged`.
+
+### Analyze Diff
+
+Derive the commit type from [`references/types.md`](references/types.md) and write a
+natural-language description summarizing what changed and why. The description must be
+imperative English, have no trailing period, and fit within 100 characters including the
+type prefix. Abort if the description is empty or is a file path instead of natural language.
+Optionally produce a body with bullet lines each starting with `-`.
+
+### Commit
+
+Run [`scripts/commit.sh`](scripts/commit.sh) with `--type`, `--description`, and
+optionally `--body`, plus `--json` for structured output. Abort if the type is not listed
+in [`references/types.md`](references/types.md) or if git commit fails.
+
+Return the JSON output from commit.sh as the final result.

--- a/.config/opencode/skills/git-commit/references/types.md
+++ b/.config/opencode/skills/git-commit/references/types.md
@@ -1,0 +1,29 @@
+# Commit Type Reference
+
+Valid types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`,
+`style`, `revert`, `i18n`.
+
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Test additions or corrections
+- `chore`: Maintenance tasks, scripts, config
+- `ci`: CI configuration and scripts
+- `build`: Build system or external dependency changes
+- `perf`: Performance improvements
+- `style`: Code style changes (formatting, whitespace)
+- `revert`: Revert previous commits
+- `i18n`: Internationalization
+
+## Selection Priority
+
+When multiple types could apply, use this priority (highest first):
+
+1. Whitespace or formatting only -> `style`
+2. Only test files changed -> `test`
+3. Only documentation files changed -> `docs`
+4. Otherwise -> analyze the diff and pick the most specific type above.
+
+Choose exactly one type. Reject any type not listed. Abort with `invalid commit type`
+on mismatch.

--- a/.config/opencode/skills/git-commit/scripts/commit.sh
+++ b/.config/opencode/skills/git-commit/scripts/commit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Allowed commit types
+ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n)
+
+# Initialize variables
+TYPE=""
+DESCRIPTION=""
+BODY=""
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    --description)
+      DESCRIPTION="$2"
+      shift 2
+      ;;
+    --body)
+      BODY="$2"
+      shift 2
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Allowed parameters: --type, --description, --body, --json" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required parameters
+if [[ -z "$TYPE" ]]; then
+  echo "Error: --type is required" >&2
+  exit 1
+fi
+
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "Error: --description is required" >&2
+  exit 1
+fi
+
+# Normalize description
+DESCRIPTION=$(printf %s "$DESCRIPTION" | sed -E 's/[[:space:]]+$//; s/,+$//')
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "Error: --description is required" >&2
+  exit 1
+fi
+
+# Guard against accidental file-path-only descriptions
+if [[ "$DESCRIPTION" == .* && "$DESCRIPTION" == */* ]]; then
+  echo "Error: --description must be a natural-language summary, not a file path" >&2
+  exit 1
+fi
+
+# Ensure there are staged files
+if ! git diff --staged --name-only | grep -q .; then
+  echo "Error: no staged files to commit" >&2
+  exit 1
+fi
+
+# Validate type
+pattern=" ${TYPE} "
+if [[ ! " ${ALLOWED_TYPES[*]} " =~ $pattern ]]; then
+  echo "Error: Invalid type '$TYPE'" >&2
+  echo "Allowed types: ${ALLOWED_TYPES[*]}" >&2
+  exit 1
+fi
+
+# Build commit message
+COMMIT_MSG="${TYPE}: ${DESCRIPTION}"
+
+if [[ -n "$BODY" ]]; then
+  COMMIT_MSG="${COMMIT_MSG}
+
+${BODY}"
+fi
+
+# Execute git commit (redirect summary to stderr so only JSON goes to stdout)
+git commit -m "$COMMIT_MSG" >&2
+
+# Output JSON if requested
+if [[ "$JSON_OUTPUT" == true ]]; then
+  SHA="$(git rev-parse HEAD)"
+  ESCAPED_MSG="${COMMIT_MSG//\\/\\\\}"
+  ESCAPED_MSG="${ESCAPED_MSG//\"/\\\"}"
+  ESCAPED_MSG="${ESCAPED_MSG//$'\n'/\\n}"
+  printf '{"sha":"%s","message":"%s"}\n' "$SHA" "$ESCAPED_MSG"
+fi

--- a/.config/opencode/skills/grill-me/SKILL.md
+++ b/.config/opencode/skills/grill-me/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+metadata:
+  original: "https://github.com/mattpocock/skills/blob/main/grill-me/SKILL.md"
+---
+
+# Grill-Me
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding.
+Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.config/opencode/skills/grill-me/SKILL.md
+++ b/.config/opencode/skills/grill-me/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: grill-me
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+description: Stress-test a plan or design by grilling the user with tough, methodical questions. Trigger on "grill me" or requests to challenge/critique a plan.
 metadata:
   original: "https://github.com/mattpocock/skills/blob/main/grill-me/SKILL.md"
 ---
 
 # Grill-Me
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding.
-Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
-For each question, provide your recommended answer.
+Act as a relentless interviewer stress-testing the user's plan or design.
+The goal is to surface blind spots, resolve ambiguities, and reach
+a fully shared understanding before implementation.
 
-Ask the questions one at a time.
+## Process
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+1. Identify the plan/design and break it into decision branches.
+2. For each branch, ask ONE question at a time.
+   - Challenge from multiple angles: edge cases, scalability,
+     security, maintainability, trade-offs, and naming.
+   - Provide your recommended answer with reasoning.
+   - If answerable by exploring the codebase, explore instead of asking.
+3. Resolve dependencies between decisions before moving to the next branch.
+4. Continue until all branches are resolved and no open questions remain.
+   - If the user says "wrap up" or wants to skip a branch, respect it
+     and move on.

--- a/.config/opencode/skills/standards-adr/SKILL.md
+++ b/.config/opencode/skills/standards-adr/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: standards-adr
+description: >-
+  Use when creating, updating, or reviewing ADRs to enforce template compliance
+  and lifecycle rules.
+---
+
+# ADR Manage
+
+Enforce ADR template compliance and lifecycle rules for all ADR operations.
+
+ADR template: [references/template.md](references/template.md).
+ADR files live in `docs/adr/`.
+
+## Create
+
+1. Determine next sequential ID: check existing files in `docs/adr/` to find the highest number, then increment.
+2. Name the file: `NNNN-slug.md` (e.g., `0001-use-postgresql.md`).
+3. Copy template from [references/template.md](references/template.md).
+4. Fill in frontmatter: `id` (zero-padded 4-digit string), `status: Proposed`, `date` (ISO 8601), `supersedes: []`.
+5. Write content per the Content Rules below.
+
+## Update Status
+
+Only the user decides when status changes. Do not change ADR status without explicit user instruction.
+
+Permitted transitions:
+
+- `Proposed` → `Accepted` or `Rejected`
+- `Accepted` → `Deprecated` or `Superseded`
+- No other transitions permitted.
+
+On supersede:
+
+1. Create a new ADR that references the old ID in its `supersedes` field.
+2. Update the old ADR `status` to `Superseded`. This is the only permitted edit to an Accepted ADR.
+
+On deprecate:
+
+- Set `status` to `Deprecated`. This is the only permitted edit to an Accepted ADR.
+
+## Review
+
+Check the following for any ADR file:
+
+- Frontmatter keys: only `id`, `status`, `date`, `supersedes` are permitted.
+- `id`: zero-padded 4-digit string matching the filename index.
+- `status`: one of `Proposed`, `Accepted`, `Deprecated`, `Superseded`, `Rejected`.
+- `date`: ISO 8601 format.
+- `supersedes`: array (empty array `[]` if none).
+- Sections present in order: `## Context`, `## Decision`, `## Consequences`. No renames, no reorders, no omissions.
+- Content of Accepted, Deprecated, or Superseded ADRs must not be modified (status field only).
+
+## Content Rules
+
+- Context: explain why the decision was needed. Include background, constraints, and alternatives with trade-offs.
+- Decision: state what was chosen and the rationale. Be specific.
+- Consequences: document positive outcomes, negative trade-offs, and risks. Be honest about downsides.
+
+## When to Write an ADR
+
+Write an ADR when either of these is true:
+
+- An AI agent asked to "clean up" the codebase would break this decision and cause bugs or cost increases.
+- This decision was learned through a past incident, failure, or painful experience.
+
+Skip the ADR and use a `// WHY:` inline comment when that comment alone conveys the rationale sufficiently.

--- a/.config/opencode/skills/standards-adr/SKILL.md
+++ b/.config/opencode/skills/standards-adr/SKILL.md
@@ -1,67 +1,35 @@
 ---
 name: standards-adr
 description: >-
-  Use when creating, updating, or reviewing ADRs to enforce template compliance
-  and lifecycle rules.
+  Use when creating or updating ADR files in docs/adr/.
+  Also use when making an architectural decision to evaluate
+  whether an ADR should be written.
 ---
 
-# ADR Manage
+# ADR Standards
 
-Enforce ADR template compliance and lifecycle rules for all ADR operations.
+## When to Write
 
-ADR template: [references/template.md](references/template.md).
-ADR files live in `docs/adr/`.
+- An AI agent asked to "clean up" the codebase would break this decision.
+- The decision was learned through a past incident or failure.
+- If a `// WHY:` inline comment alone conveys the rationale, skip the ADR.
 
 ## Create
 
-1. Determine next sequential ID: check existing files in `docs/adr/` to find the highest number, then increment.
-2. Name the file: `NNNN-slug.md` (e.g., `0001-use-postgresql.md`).
-3. Copy template from [references/template.md](references/template.md).
-4. Fill in frontmatter: `id` (zero-padded 4-digit string), `status: Proposed`, `date` (ISO 8601), `supersedes: []`.
-5. Write content per the Content Rules below.
+1. Find the highest ID in `docs/adr/`, increment by one.
+2. Name: `NNNN-slug.md`
+3. Copy [references/template.md](references/template.md) and fill in content.
 
 ## Update Status
 
-Only the user decides when status changes. Do not change ADR status without explicit user instruction.
+Only the user decides status changes.
 
 Permitted transitions:
 
 - `Proposed` → `Accepted` or `Rejected`
 - `Accepted` → `Deprecated` or `Superseded`
-- No other transitions permitted.
 
-On supersede:
+On supersede: Create a new ADR with old ID in `supersedes`. Set old ADR to `Superseded`.
+On deprecate: Set old ADR to `Deprecated`.
 
-1. Create a new ADR that references the old ID in its `supersedes` field.
-2. Update the old ADR `status` to `Superseded`. This is the only permitted edit to an Accepted ADR.
-
-On deprecate:
-
-- Set `status` to `Deprecated`. This is the only permitted edit to an Accepted ADR.
-
-## Review
-
-Check the following for any ADR file:
-
-- Frontmatter keys: only `id`, `status`, `date`, `supersedes` are permitted.
-- `id`: zero-padded 4-digit string matching the filename index.
-- `status`: one of `Proposed`, `Accepted`, `Deprecated`, `Superseded`, `Rejected`.
-- `date`: ISO 8601 format.
-- `supersedes`: array (empty array `[]` if none).
-- Sections present in order: `## Context`, `## Decision`, `## Consequences`. No renames, no reorders, no omissions.
-- Content of Accepted, Deprecated, or Superseded ADRs must not be modified (status field only).
-
-## Content Rules
-
-- Context: explain why the decision was needed. Include background, constraints, and alternatives with trade-offs.
-- Decision: state what was chosen and the rationale. Be specific.
-- Consequences: document positive outcomes, negative trade-offs, and risks. Be honest about downsides.
-
-## When to Write an ADR
-
-Write an ADR when either of these is true:
-
-- An AI agent asked to "clean up" the codebase would break this decision and cause bugs or cost increases.
-- This decision was learned through a past incident, failure, or painful experience.
-
-Skip the ADR and use a `// WHY:` inline comment when that comment alone conveys the rationale sufficiently.
+Status is the only permitted edit to an Accepted ADR.

--- a/.config/opencode/skills/standards-adr/references/template.md
+++ b/.config/opencode/skills/standards-adr/references/template.md
@@ -1,0 +1,20 @@
+---
+id: "0000"
+status: Proposed
+date: YYYY-MM-DD
+supersedes: []
+---
+
+# ADR-0000: [Short Title]
+
+## Context
+
+Why we needed to make this decision. Background, constraints, and alternatives considered.
+
+## Decision
+
+What we decided and the rationale.
+
+## Consequences
+
+What happens as a result. Include positive, negative, and risks.

--- a/.config/opencode/skills/standards-adr/references/template.md
+++ b/.config/opencode/skills/standards-adr/references/template.md
@@ -5,16 +5,19 @@ date: YYYY-MM-DD
 supersedes: []
 ---
 
-# ADR-0000: [Short Title]
+# ADR-0000: Short Title
+
+> Frontmatter keys: only id, status, date, supersedes. No additions.
+> id: zero-padded 4-digit string matching filename index
 
 ## Context
 
-Why we needed to make this decision. Background, constraints, and alternatives considered.
+Why this decision was needed. Background, constraints, alternatives with trade-offs.
 
 ## Decision
 
-What we decided and the rationale.
+What was chosen and the rationale. Be specific.
 
 ## Consequences
 
-What happens as a result. Include positive, negative, and risks.
+Positive outcomes, negative trade-offs, and risks. Be honest about downsides.

--- a/.config/opencode/skills/standards-code/SKILL.md
+++ b/.config/opencode/skills/standards-code/SKILL.md
@@ -2,15 +2,24 @@
 name: standards-code
 description: >-
   Use when writing or reviewing code in Bash, Go, Python, Rust, or TypeScript
-  to enforce language-specific coding standards.
+  to enforce coding standards.
 ---
 
-# Language Coding Standards
+# Coding Standards
 
-Select the reference for the language in use:
+## Principles
 
-- Bash (`.sh` files): [references/bash.md](references/bash.md)
-- Go (`.go` files): [references/go.md](references/go.md)
-- Python (`.py` files): [references/python.md](references/python.md)
-- Rust (`.rs` files): [references/rust.md](references/rust.md)
-- TypeScript (`.ts`, `.tsx` files): [references/typescript.md](references/typescript.md)
+- Handle errors explicitly. Do not swallow errors silently.
+- Depend on abstractions, not concrete implementations.
+- Validate external input at the boundary. Do not trust unvalidated data beyond that point.
+- Keep public API surface minimal. Do not export internal implementation details.
+- Inject dependencies. Do not rely on global mutable state.
+- Use structured logging. Do not use print statements for operational output.
+
+## Language References
+
+- Bash: [references/bash.md](references/bash.md)
+- Go: [references/go.md](references/go.md)
+- Python: [references/python.md](references/python.md)
+- Rust: [references/rust.md](references/rust.md)
+- TypeScript: [references/typescript.md](references/typescript.md)

--- a/.config/opencode/skills/standards-code/SKILL.md
+++ b/.config/opencode/skills/standards-code/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: standards-code
+description: >-
+  Use when writing or reviewing code in Bash, Go, Python, Rust, or TypeScript
+  to enforce language-specific coding standards.
+---
+
+# Language Coding Standards
+
+Select the reference for the language in use:
+
+- Bash (`.sh` files): [references/bash.md](references/bash.md)
+- Go (`.go` files): [references/go.md](references/go.md)
+- Python (`.py` files): [references/python.md](references/python.md)
+- Rust (`.rs` files): [references/rust.md](references/rust.md)
+- TypeScript (`.ts`, `.tsx` files): [references/typescript.md](references/typescript.md)

--- a/.config/opencode/skills/standards-code/references/bash-template.sh
+++ b/.config/opencode/skills/standards-code/references/bash-template.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# [Short description]
+
+set -Eeuo pipefail
+
+SCRIPT_NAME=$(basename "${0}")
+readonly SCRIPT_NAME
+
+function log_info() {
+  local message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [$SCRIPT_NAME] [INFO] $message" >&2
+}
+
+function log_err() {
+  local message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [$SCRIPT_NAME] [ERROR] $message" >&2
+}
+
+function err() {
+  log_err "Line $1: $2"
+  exit 1
+}
+
+trap 'err ${LINENO} "$BASH_COMMAND"' ERR
+
+function usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Description:
+    [Short description]
+
+OPTIONS:
+    -h, --help      Show this help message
+    -v, --verbose   Enable verbose output (set -x)
+
+EXAMPLES:
+    ${SCRIPT_NAME}
+    ${SCRIPT_NAME} --verbose
+    ${SCRIPT_NAME} --help
+EOF
+}
+
+function main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -v | --verbose)
+      set -x
+      shift
+      ;;
+    *)
+      log_err "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+    esac
+  done
+
+  # Main logic here
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/opencode/skills/standards-code/references/bash-template.sh
+++ b/.config/opencode/skills/standards-code/references/bash-template.sh
@@ -44,19 +44,19 @@ EOF
 function main() {
   while [[ $# -gt 0 ]]; do
     case $1 in
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    -v | --verbose)
-      set -x
-      shift
-      ;;
-    *)
-      log_err "Unknown option: $1"
-      usage
-      exit 1
-      ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -v | --verbose)
+        set -x
+        shift
+        ;;
+      *)
+        log_err "Unknown option: $1"
+        usage
+        exit 1
+        ;;
     esac
   done
 

--- a/.config/opencode/skills/standards-code/references/bash.md
+++ b/.config/opencode/skills/standards-code/references/bash.md
@@ -1,0 +1,58 @@
+# Bash
+
+## Architecture
+
+- Keep each function focused on one responsibility with a single observable effect.
+- Declare functions before first use in the same file.
+- Pass data into functions via arguments instead of relying on implicit global state.
+- Do not mutate global variables from helper functions unless the variable name is documented at file scope.
+- Do not source another script using a relative path without anchoring it to the current script directory.
+
+## Error Handling
+
+- Validate required argument counts at the start of each public function.
+- Return non-zero from functions on failure and propagate that failure to callers.
+- Send diagnostic error messages to stderr.
+- Do not ignore command failures by appending `|| true` unless the failure is explicitly expected and handled.
+- Do not continue execution after a failed precondition check.
+
+## Security
+
+- Document intentional unquoted expansions inline when relying on controlled word splitting or glob expansion.
+- Use `--` to terminate option parsing before passing user-controlled values to external commands.
+- Create temporary files and directories with `mktemp`.
+- Pass secrets through environment variables or temporary files with mode 0600. Clear or unset secret variables after use.
+- Do not execute user-controlled data as shell code.
+- Do not embed secrets in command arguments that are visible via process listings.
+- Do not log or echo secrets to stdout or stderr.
+- Do not use `eval` unless input is constant and defined within the same file.
+
+## Naming Conventions
+
+- Use lowercase snake_case for function names.
+- Use uppercase snake_case for exported environment variables.
+- Use descriptive variable names that encode intent, not implementation detail.
+- Do not reuse the same variable name for unrelated meanings within the same function.
+- Do not use single-letter names outside loop iterators.
+
+## Idioms
+
+- Split complex command substitutions into named intermediate variables to preserve readability and safe nesting.
+- Use `printf` for formatted or escaped output.
+- Iterate over arrays with `for item in "${array[@]}"; do` to preserve element boundaries.
+- Use null-delimited file enumeration patterns when filenames may contain whitespace, newlines, or glob characters.
+- Do not use unbounded pipelines when a direct shell builtin can express the same check.
+
+## Portability
+
+- Document required shell and tool assumptions at the top of the file.
+- Gate shell-specific features behind an explicit shell compatibility check.
+- Prefer POSIX-compliant constructs when bash-specific behavior is not required.
+- Do not rely on GNU-only command flags without a fallback for BSD or POSIX variants.
+- Do not hardcode platform-specific absolute paths when a standard environment variable can be used.
+
+## Testing
+
+- Mock external commands in tests by overriding `PATH` with test doubles.
+- Run shell script tests in isolated temporary directories and clean up artifacts after each test.
+- Do not run shell script tests against real production resources, user home directories, or live network services.

--- a/.config/opencode/skills/standards-code/references/bash.md
+++ b/.config/opencode/skills/standards-code/references/bash.md
@@ -1,58 +1,11 @@
 # Bash
 
-## Architecture
-
-- Keep each function focused on one responsibility with a single observable effect.
-- Declare functions before first use in the same file.
-- Pass data into functions via arguments instead of relying on implicit global state.
-- Do not mutate global variables from helper functions unless the variable name is documented at file scope.
-- Do not source another script using a relative path without anchoring it to the current script directory.
-
-## Error Handling
-
+- Template: [references/bash-template.sh](references/bash-template.sh)
+- Pass data into functions via arguments. Do not rely on implicit global state.
 - Validate required argument counts at the start of each public function.
-- Return non-zero from functions on failure and propagate that failure to callers.
-- Send diagnostic error messages to stderr.
-- Do not ignore command failures by appending `|| true` unless the failure is explicitly expected and handled.
-- Do not continue execution after a failed precondition check.
-
-## Security
-
-- Document intentional unquoted expansions inline when relying on controlled word splitting or glob expansion.
-- Use `--` to terminate option parsing before passing user-controlled values to external commands.
-- Create temporary files and directories with `mktemp`.
-- Pass secrets through environment variables or temporary files with mode 0600. Clear or unset secret variables after use.
-- Do not execute user-controlled data as shell code.
-- Do not embed secrets in command arguments that are visible via process listings.
-- Do not log or echo secrets to stdout or stderr.
+- Send diagnostic messages to stderr. Return non-zero on failure.
+- Use `mktemp` for temporary files. Pass secrets via environment variables or files with mode 0600.
 - Do not use `eval` unless input is constant and defined within the same file.
-
-## Naming Conventions
-
-- Use lowercase snake_case for function names.
-- Use uppercase snake_case for exported environment variables.
-- Use descriptive variable names that encode intent, not implementation detail.
-- Do not reuse the same variable name for unrelated meanings within the same function.
-- Do not use single-letter names outside loop iterators.
-
-## Idioms
-
-- Split complex command substitutions into named intermediate variables to preserve readability and safe nesting.
-- Use `printf` for formatted or escaped output.
-- Iterate over arrays with `for item in "${array[@]}"; do` to preserve element boundaries.
-- Use null-delimited file enumeration patterns when filenames may contain whitespace, newlines, or glob characters.
-- Do not use unbounded pipelines when a direct shell builtin can express the same check.
-
-## Portability
-
+- Use `printf` for formatted output. Use `"${array[@]}"` for safe iteration.
 - Document required shell and tool assumptions at the top of the file.
-- Gate shell-specific features behind an explicit shell compatibility check.
-- Prefer POSIX-compliant constructs when bash-specific behavior is not required.
-- Do not rely on GNU-only command flags without a fallback for BSD or POSIX variants.
-- Do not hardcode platform-specific absolute paths when a standard environment variable can be used.
-
-## Testing
-
 - Mock external commands in tests by overriding `PATH` with test doubles.
-- Run shell script tests in isolated temporary directories and clean up artifacts after each test.
-- Do not run shell script tests against real production resources, user home directories, or live network services.

--- a/.config/opencode/skills/standards-code/references/go.md
+++ b/.config/opencode/skills/standards-code/references/go.md
@@ -1,63 +1,12 @@
 # Go
 
-## Official Documentation
-
-When encountering unfamiliar Go APIs or patterns, use a subagent to fetch
-the relevant specification details from the official documentation:
-
-- [Effective Go](https://go.dev/doc/effective_go)
-- [Go Standard Library](https://pkg.go.dev/std)
-
-## Architecture
-
-- Pass `context.Context` as the first parameter to all blocking and IO
-  operations. Do not discard a context received from a caller. Cancel contexts
-  when they are no longer needed to avoid resource leaks.
-- Accept interfaces, return concrete types. Keep interfaces small and focused to
-  a single behavior. Define interfaces at the consumer, not the producer.
-- Use dependency injection via interfaces to keep components testable without global state.
-- Use the functional options pattern for optional configuration on exported types.
-- Do not use `init()` for side effects that depend on external state or ordering guarantees.
-- Do not export identifiers that are not part of the intentional public API.
-
-## Concurrency
-
-- Ensure every goroutine has a clear termination path. Do not leak goroutines.
-- Document goroutine ownership and lifetime at the call site or in a package-level comment.
-- Use channels for goroutine orchestration. Use mutexes for protecting shared
-  mutable state. Do not share mutable state across goroutines without
-  synchronization.
-- Use `sync.WaitGroup` or `errgroup` to coordinate goroutine completion.
-- Do not use goroutines inside library functions without a documented lifecycle contract.
-- Implement graceful shutdown for long-running services, honoring context cancellation.
-
-## Error Handling
-
-- Wrap errors with context using `fmt.Errorf("...: %w", err)` or `errors.Join`. Do not discard errors silently.
-- Propagate errors explicitly up the call stack. Check errors from defer calls
-  (e.g., `Close`, `Commit`) and propagate them to the caller. Do not ignore the
-  return value of functions that return an error.
-- Do not use `panic` for normal error handling. Reserve panic for unrecoverable programmer errors only.
-- Define sentinel errors with `errors.New` and custom error types with
-  `Error() string` for structured handling. Use `errors.Is` and `errors.As`
-  for error inspection. Do not compare error strings directly.
-
-## Performance
-
-- Use connection pooling for database and HTTP clients. Do not create a new client per request.
-- Set appropriate timeouts on HTTP clients, servers, and database connections.
-- Pre-allocate slices and maps with `make` when the size is known to avoid repeated allocations.
-- Use `sync.Pool` for frequently allocated short-lived objects in hot paths.
-- Do not use `reflect` or `unsafe` outside of well-justified, isolated packages with clear documentation.
-- Clean up resources in defer immediately after acquisition to ensure release on all code paths.
-
-## Logging
-
-- Use structured logging (e.g., `slog`) with consistent fields. Do not use `fmt.Println` for operational logs.
-
-## Testing
-
-- Use table-driven tests with subtests to cover edge cases and improve test readability.
-- Use interfaces and dependency injection to allow unit testing without external dependencies.
-- Treat data races as correctness bugs. Run tests with the race detector to surface them.
-- Test concurrent code with repeated runs to surface non-deterministic failures.
+- Official docs: [Effective Go](https://go.dev/doc/effective_go), [Standard Library](https://pkg.go.dev/std)
+- Pass `context.Context` as the first parameter to all blocking and IO operations.
+- Accept interfaces, return concrete types. Define interfaces at the consumer.
+- Use functional options pattern for optional configuration.
+- Wrap errors with `fmt.Errorf("...: %w", err)`. Define sentinel errors with `errors.New`.
+- Use `errors.Is` and `errors.As` for inspection. Do not compare error strings.
+- Ensure every goroutine has a clear termination path. Use `errgroup` for coordination.
+- Pre-allocate slices and maps with `make` when size is known.
+- Use `slog` for structured logging.
+- Use table-driven tests with subtests. Run tests with the race detector.

--- a/.config/opencode/skills/standards-code/references/go.md
+++ b/.config/opencode/skills/standards-code/references/go.md
@@ -1,0 +1,63 @@
+# Go
+
+## Official Documentation
+
+When encountering unfamiliar Go APIs or patterns, use a subagent to fetch
+the relevant specification details from the official documentation:
+
+- [Effective Go](https://go.dev/doc/effective_go)
+- [Go Standard Library](https://pkg.go.dev/std)
+
+## Architecture
+
+- Pass `context.Context` as the first parameter to all blocking and IO
+  operations. Do not discard a context received from a caller. Cancel contexts
+  when they are no longer needed to avoid resource leaks.
+- Accept interfaces, return concrete types. Keep interfaces small and focused to
+  a single behavior. Define interfaces at the consumer, not the producer.
+- Use dependency injection via interfaces to keep components testable without global state.
+- Use the functional options pattern for optional configuration on exported types.
+- Do not use `init()` for side effects that depend on external state or ordering guarantees.
+- Do not export identifiers that are not part of the intentional public API.
+
+## Concurrency
+
+- Ensure every goroutine has a clear termination path. Do not leak goroutines.
+- Document goroutine ownership and lifetime at the call site or in a package-level comment.
+- Use channels for goroutine orchestration. Use mutexes for protecting shared
+  mutable state. Do not share mutable state across goroutines without
+  synchronization.
+- Use `sync.WaitGroup` or `errgroup` to coordinate goroutine completion.
+- Do not use goroutines inside library functions without a documented lifecycle contract.
+- Implement graceful shutdown for long-running services, honoring context cancellation.
+
+## Error Handling
+
+- Wrap errors with context using `fmt.Errorf("...: %w", err)` or `errors.Join`. Do not discard errors silently.
+- Propagate errors explicitly up the call stack. Check errors from defer calls
+  (e.g., `Close`, `Commit`) and propagate them to the caller. Do not ignore the
+  return value of functions that return an error.
+- Do not use `panic` for normal error handling. Reserve panic for unrecoverable programmer errors only.
+- Define sentinel errors with `errors.New` and custom error types with
+  `Error() string` for structured handling. Use `errors.Is` and `errors.As`
+  for error inspection. Do not compare error strings directly.
+
+## Performance
+
+- Use connection pooling for database and HTTP clients. Do not create a new client per request.
+- Set appropriate timeouts on HTTP clients, servers, and database connections.
+- Pre-allocate slices and maps with `make` when the size is known to avoid repeated allocations.
+- Use `sync.Pool` for frequently allocated short-lived objects in hot paths.
+- Do not use `reflect` or `unsafe` outside of well-justified, isolated packages with clear documentation.
+- Clean up resources in defer immediately after acquisition to ensure release on all code paths.
+
+## Logging
+
+- Use structured logging (e.g., `slog`) with consistent fields. Do not use `fmt.Println` for operational logs.
+
+## Testing
+
+- Use table-driven tests with subtests to cover edge cases and improve test readability.
+- Use interfaces and dependency injection to allow unit testing without external dependencies.
+- Treat data races as correctness bugs. Run tests with the race detector to surface them.
+- Test concurrent code with repeated runs to surface non-deterministic failures.

--- a/.config/opencode/skills/standards-code/references/python.md
+++ b/.config/opencode/skills/standards-code/references/python.md
@@ -1,57 +1,13 @@
 # Python
 
-## Official Documentation
-
-When encountering unfamiliar Python APIs or patterns, use a subagent to fetch
-the relevant specification details from the official documentation:
-
-- [Python Standard Library](https://docs.python.org/3/library/index.html)
-
-## Architecture
-
+- Official docs: [Standard Library](https://docs.python.org/3/library/index.html)
 - Use dataclasses or Pydantic models for structured data. Do not pass raw dicts across module boundaries.
-- Use `__all__` to declare the public API of a module explicitly.
-- Do not use wildcard imports (`from module import *`) in production code.
-- Use dependency injection for testability. Do not rely on global mutable state.
+- Add type hints to all function signatures. Enable mypy strict mode for public APIs.
+- Use `Protocol` for structural typing. Prefer `Protocol` over `ABC`.
+- Define custom exception hierarchies for domain errors. Do not raise bare `Exception`.
+- Use `pathlib.Path` instead of `os.path`.
 - Do not use mutable default arguments in function signatures.
-- Use `pathlib.Path` instead of `os.path` for filesystem operations.
-
-## Type Safety
-
-- Add type hints to all function signatures and class attributes.
-- Enable mypy strict mode for public APIs.
-- Use `Protocol` for structural typing. Prefer `Protocol` over `ABC` for duck-typed interfaces.
-
-## Error Handling
-
-- Do not raise bare `Exception`. Define custom exception hierarchies for domain errors.
-- Handle exceptions at the appropriate architectural layer. Do not swallow exceptions silently.
-- Do not catch broad exception types (`Exception`, `BaseException`) unless re-raising or logging and re-raising.
-
-## Async
-
-- Do not mix sync blocking calls inside async functions.
-- Use async context managers for async resources.
-- Use `asyncio.TaskGroup` for structured concurrency.
-
-## Security
-
-- Validate and sanitize external input before use.
-- Do not interpolate user input directly into SQL queries. Use parameterized queries.
-- Do not hardcode secrets. Read secrets from environment variables or a secret manager.
-
-## Performance
-
-- Use context managers (`with`) for file, network, and database resources.
-- Use generators for large datasets to avoid memory exhaustion.
-- Prefer comprehensions over explicit loops for simple transformations.
-
-## Logging
-
-- Use `logging` with structured fields. Do not use `print` for operational output.
-
-## Testing
-
-- Write tests with pytest. Use fixtures to isolate test data from production data.
-- Use `parametrize` for edge-case coverage. Do not duplicate test bodies for similar cases.
-- Mock external I/O (HTTP, DB, filesystem) at service boundaries. Do not hit real endpoints in unit tests.
+- Use `asyncio.TaskGroup` for structured concurrency. Do not mix sync blocking calls in async functions.
+- Use parameterized queries for SQL. Do not interpolate user input.
+- Use `logging` with structured fields.
+- Use pytest with `parametrize` for edge-case coverage. Mock external I/O at service boundaries.

--- a/.config/opencode/skills/standards-code/references/python.md
+++ b/.config/opencode/skills/standards-code/references/python.md
@@ -1,0 +1,57 @@
+# Python
+
+## Official Documentation
+
+When encountering unfamiliar Python APIs or patterns, use a subagent to fetch
+the relevant specification details from the official documentation:
+
+- [Python Standard Library](https://docs.python.org/3/library/index.html)
+
+## Architecture
+
+- Use dataclasses or Pydantic models for structured data. Do not pass raw dicts across module boundaries.
+- Use `__all__` to declare the public API of a module explicitly.
+- Do not use wildcard imports (`from module import *`) in production code.
+- Use dependency injection for testability. Do not rely on global mutable state.
+- Do not use mutable default arguments in function signatures.
+- Use `pathlib.Path` instead of `os.path` for filesystem operations.
+
+## Type Safety
+
+- Add type hints to all function signatures and class attributes.
+- Enable mypy strict mode for public APIs.
+- Use `Protocol` for structural typing. Prefer `Protocol` over `ABC` for duck-typed interfaces.
+
+## Error Handling
+
+- Do not raise bare `Exception`. Define custom exception hierarchies for domain errors.
+- Handle exceptions at the appropriate architectural layer. Do not swallow exceptions silently.
+- Do not catch broad exception types (`Exception`, `BaseException`) unless re-raising or logging and re-raising.
+
+## Async
+
+- Do not mix sync blocking calls inside async functions.
+- Use async context managers for async resources.
+- Use `asyncio.TaskGroup` for structured concurrency.
+
+## Security
+
+- Validate and sanitize external input before use.
+- Do not interpolate user input directly into SQL queries. Use parameterized queries.
+- Do not hardcode secrets. Read secrets from environment variables or a secret manager.
+
+## Performance
+
+- Use context managers (`with`) for file, network, and database resources.
+- Use generators for large datasets to avoid memory exhaustion.
+- Prefer comprehensions over explicit loops for simple transformations.
+
+## Logging
+
+- Use `logging` with structured fields. Do not use `print` for operational output.
+
+## Testing
+
+- Write tests with pytest. Use fixtures to isolate test data from production data.
+- Use `parametrize` for edge-case coverage. Do not duplicate test bodies for similar cases.
+- Mock external I/O (HTTP, DB, filesystem) at service boundaries. Do not hit real endpoints in unit tests.

--- a/.config/opencode/skills/standards-code/references/rust.md
+++ b/.config/opencode/skills/standards-code/references/rust.md
@@ -1,0 +1,64 @@
+# Rust
+
+## Official Documentation
+
+When encountering unfamiliar Rust APIs or patterns, use a subagent to fetch
+the relevant specification details from the official documentation:
+
+- [Rust Standard Library](https://doc.rust-lang.org/std/)
+- [The Rust Reference](https://doc.rust-lang.org/reference/)
+
+## Safety
+
+- Isolate unsafe blocks in dedicated abstraction layers. Do not use unsafe in application logic.
+- Document safety invariants for every unsafe block with a SAFETY comment. Do
+  not write unsafe code without a corresponding encapsulating safe abstraction
+  that upholds invariants.
+- Verify unsafe code produces no undefined behavior before merging. Use MIRI for this.
+- Verify unsafe code paths produce no memory errors. Use address sanitizer for this.
+- Document drop order dependencies when they affect correctness or resource cleanup.
+- Do not expose mutable global state. Prefer dependency injection via function arguments or struct fields.
+- Use type-state patterns to enforce state machine invariants at compile time.
+
+## Error Handling
+
+- Do not use `panic!` for recoverable errors. Return `Result` or `Option`
+  instead. Reserve `panic!` exclusively for programmer errors such as invariant
+  violations.
+- Design public APIs to be panic-free. Document all functions that may panic explicitly in their doc comments.
+- Use `?` for error propagation. Do not swallow errors silently.
+- Define custom error types with `thiserror` for library crates. Use `anyhow`
+  for error handling in application crates. Do not expose internal error
+  details across library API boundaries without wrapping.
+- Implement `Display` and `Debug` for all public error types. Implement `From`
+  conversions to avoid manual mapping where idiomatic.
+
+## Memory and Dependencies
+
+- Prefer ownership transfer over cloning when performance matters. Prefer
+  borrowing over cloning for read-only access. Do not clone data in hot paths
+  without profiling justification.
+- Commit `Cargo.lock` for binaries and applications for reproducibility. Do not commit `Cargo.lock` for library crates.
+- Run `cargo audit` in CI to detect vulnerable dependencies. Do not introduce a
+  new dependency without auditing it for soundness and maintenance status.
+- Benchmark before optimizing performance-critical code paths. Use `criterion` for reproducible benchmark comparisons.
+
+## Concurrency
+
+- Verify `Send` + `Sync` bounds for types shared across threads. Do not share non-`Sync` types across threads.
+- Use channels for orchestration and `Mutex`/`RwLock` for shared state.
+- Manage thread and task lifetimes explicitly. Do not leak threads.
+- Propagate context (cancellation, deadlines) through async call chains. Do not
+  block the async executor with synchronous I/O. Use `spawn_blocking` for
+  blocking calls.
+- Pin futures that require a stable address. Document why pinning is necessary.
+
+## Documentation
+
+- Document all public items. Do not leave exported symbols without doc comments.
+
+## Testing
+
+- Write table-driven and property-based tests for correctness.
+- Fuzz parsing and deserialization logic with `cargo-fuzz`.
+- Use the ThreadSanitizer or race detector for concurrent code tests.

--- a/.config/opencode/skills/standards-code/references/rust.md
+++ b/.config/opencode/skills/standards-code/references/rust.md
@@ -1,64 +1,13 @@
 # Rust
 
-## Official Documentation
-
-When encountering unfamiliar Rust APIs or patterns, use a subagent to fetch
-the relevant specification details from the official documentation:
-
-- [Rust Standard Library](https://doc.rust-lang.org/std/)
-- [The Rust Reference](https://doc.rust-lang.org/reference/)
-
-## Safety
-
-- Isolate unsafe blocks in dedicated abstraction layers. Do not use unsafe in application logic.
-- Document safety invariants for every unsafe block with a SAFETY comment. Do
-  not write unsafe code without a corresponding encapsulating safe abstraction
-  that upholds invariants.
-- Verify unsafe code produces no undefined behavior before merging. Use MIRI for this.
-- Verify unsafe code paths produce no memory errors. Use address sanitizer for this.
-- Document drop order dependencies when they affect correctness or resource cleanup.
-- Do not expose mutable global state. Prefer dependency injection via function arguments or struct fields.
-- Use type-state patterns to enforce state machine invariants at compile time.
-
-## Error Handling
-
-- Do not use `panic!` for recoverable errors. Return `Result` or `Option`
-  instead. Reserve `panic!` exclusively for programmer errors such as invariant
-  violations.
-- Design public APIs to be panic-free. Document all functions that may panic explicitly in their doc comments.
-- Use `?` for error propagation. Do not swallow errors silently.
-- Define custom error types with `thiserror` for library crates. Use `anyhow`
-  for error handling in application crates. Do not expose internal error
-  details across library API boundaries without wrapping.
-- Implement `Display` and `Debug` for all public error types. Implement `From`
-  conversions to avoid manual mapping where idiomatic.
-
-## Memory and Dependencies
-
-- Prefer ownership transfer over cloning when performance matters. Prefer
-  borrowing over cloning for read-only access. Do not clone data in hot paths
-  without profiling justification.
-- Commit `Cargo.lock` for binaries and applications for reproducibility. Do not commit `Cargo.lock` for library crates.
-- Run `cargo audit` in CI to detect vulnerable dependencies. Do not introduce a
-  new dependency without auditing it for soundness and maintenance status.
-- Benchmark before optimizing performance-critical code paths. Use `criterion` for reproducible benchmark comparisons.
-
-## Concurrency
-
-- Verify `Send` + `Sync` bounds for types shared across threads. Do not share non-`Sync` types across threads.
-- Use channels for orchestration and `Mutex`/`RwLock` for shared state.
-- Manage thread and task lifetimes explicitly. Do not leak threads.
-- Propagate context (cancellation, deadlines) through async call chains. Do not
-  block the async executor with synchronous I/O. Use `spawn_blocking` for
-  blocking calls.
-- Pin futures that require a stable address. Document why pinning is necessary.
-
-## Documentation
-
-- Document all public items. Do not leave exported symbols without doc comments.
-
-## Testing
-
-- Write table-driven and property-based tests for correctness.
-- Fuzz parsing and deserialization logic with `cargo-fuzz`.
-- Use the ThreadSanitizer or race detector for concurrent code tests.
+- Official docs: [Standard Library](https://doc.rust-lang.org/std/), [Reference](https://doc.rust-lang.org/reference/)
+- Isolate `unsafe` in dedicated abstraction layers. Document safety invariants with a SAFETY comment.
+- Return `Result` or `Option` for recoverable errors. Reserve `panic!` for invariant violations only.
+- Use `thiserror` for library crates, `anyhow` for application crates.
+- Use `?` for propagation. Implement `Display` and `Debug` for public error types.
+- Depend on trait bounds, not concrete types. Use type-state patterns for state machine invariants.
+- Prefer ownership transfer over cloning in hot paths. Prefer borrowing for read-only access.
+- Verify `Send` + `Sync` bounds for types shared across threads.
+- Use `spawn_blocking` for blocking calls in async context.
+- Commit `Cargo.lock` for binaries only. Run `cargo audit` in CI.
+- Document all public items. Fuzz parsing logic with `cargo-fuzz`.

--- a/.config/opencode/skills/standards-code/references/typescript.md
+++ b/.config/opencode/skills/standards-code/references/typescript.md
@@ -1,61 +1,13 @@
 # TypeScript
 
-## Official Documentation
-
-When encountering unfamiliar TypeScript APIs or patterns, use a subagent to fetch
-the relevant specification details from the official documentation:
-
-- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
-
-## Type Safety
-
-- Enable strict mode in tsconfig. Do not disable strict compiler flags.
-- Do not use `any` without an explicit justification comment. Treat untyped `any` as a bug. Use
-  `unknown` instead of `any` as the initial type for values whose shape is not yet established.
-- Use branded/opaque types for domain primitives (IDs, monetary amounts) to prevent accidental mixing.
-- Use discriminated unions to model state machines and sum types. Do not use string/number enums as
-  a substitute. Use exhaustive checks (`never` type) in switch/if-else over discriminated unions to
-  catch missing cases at compile time.
-- Use type guards and discriminated unions for type narrowing. Do not use `as` for narrowing inside
-  business logic. Cast only at a validated runtime boundary where schema validation has already
-  occurred.
-- Use `as const` to infer literal types from object and array literals. Use the `satisfies`
-  operator to validate a value against a type without widening it.
-- Define explicit generic constraints. Do not leave unconstrained generics where a tighter bound is possible.
-- Prefer `interface` over type alias for object shapes that may be extended by consumers. Use type
-  alias for unions, intersections, and mapped types.
-- Use `Readonly<T>` or `ReadonlyArray<T>` for data that must not be mutated after construction.
-- Do not use `Function` or `object` as a type annotation. Use the most specific callable or object type possible.
-
-## Architecture
-
-- Define explicit input and output types for all public functions and API handlers. Do not rely on
-  inferred return types at public API boundaries.
-- Validate external data (API responses, environment variables, user input) with a runtime schema
-  library (zod, io-ts) before treating it as a typed value. Validate environment variable values at
-  application startup with a typed schema. Do not access `process.env` inline throughout the
-  codebase.
-- Co-locate domain types with the module that owns them. Do not define domain types in a global or
-  shared utility file unless they are genuinely cross-cutting.
-- Do not expose internal implementation types in public module interfaces. Keep the public surface minimal.
-- Do not use type augmentation on third-party modules unless strictly necessary. Document the reason inline.
-- Use type-only imports (`import type`) when importing types that are not needed at runtime.
-- Do not mutate function arguments. Prefer readonly arrays and readonly object types for data
-  passed across module or function boundaries.
-
-## Error Handling
-
-- Use Result/Either types or discriminated union error types for recoverable errors in library
-  code. Do not throw for control flow.
-- Do not swallow errors silently. Propagate or log with sufficient context.
-- Handle `null` and `undefined` explicitly in all code paths. Do not use the non-null assertion
-  operator (`!`) on values that could legitimately be null or undefined.
-- Define error types that carry enough context for the caller to handle them. Do not use raw
-  `Error` with only a message string for domain errors.
-- Model async operation states with explicit discriminated unions (idle, loading, success, error).
-  Do not use multiple boolean flags.
-- Annotate the return type of async functions explicitly. Do not rely on inference across async boundaries.
-
-## Testing
-
-- Write unit tests that verify type-narrowing branches produce the correct runtime behavior.
+- Official docs: [Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
+- Enable strict mode. Do not use `any` without an explicit justification comment. Use `unknown` instead.
+- Use branded types for domain primitives (IDs, monetary amounts).
+- Use discriminated unions for state machines and error types. Use exhaustive checks with `never`.
+- Use `as const` and `satisfies` for literal type inference without widening.
+- Use `Readonly<T>` and `ReadonlyArray<T>` for immutable data. Do not mutate function arguments.
+- Use `import type` for type-only imports.
+- Validate external data with a runtime schema library (zod, io-ts) at the boundary.
+- Validate environment variables at startup with a typed schema. Do not access `process.env` inline.
+- Use Result or discriminated union error types for recoverable errors. Do not throw for control flow.
+- Model async states with discriminated unions (idle, loading, success, error). Do not use boolean flags.

--- a/.config/opencode/skills/standards-code/references/typescript.md
+++ b/.config/opencode/skills/standards-code/references/typescript.md
@@ -1,0 +1,61 @@
+# TypeScript
+
+## Official Documentation
+
+When encountering unfamiliar TypeScript APIs or patterns, use a subagent to fetch
+the relevant specification details from the official documentation:
+
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
+
+## Type Safety
+
+- Enable strict mode in tsconfig. Do not disable strict compiler flags.
+- Do not use `any` without an explicit justification comment. Treat untyped `any` as a bug. Use
+  `unknown` instead of `any` as the initial type for values whose shape is not yet established.
+- Use branded/opaque types for domain primitives (IDs, monetary amounts) to prevent accidental mixing.
+- Use discriminated unions to model state machines and sum types. Do not use string/number enums as
+  a substitute. Use exhaustive checks (`never` type) in switch/if-else over discriminated unions to
+  catch missing cases at compile time.
+- Use type guards and discriminated unions for type narrowing. Do not use `as` for narrowing inside
+  business logic. Cast only at a validated runtime boundary where schema validation has already
+  occurred.
+- Use `as const` to infer literal types from object and array literals. Use the `satisfies`
+  operator to validate a value against a type without widening it.
+- Define explicit generic constraints. Do not leave unconstrained generics where a tighter bound is possible.
+- Prefer `interface` over type alias for object shapes that may be extended by consumers. Use type
+  alias for unions, intersections, and mapped types.
+- Use `Readonly<T>` or `ReadonlyArray<T>` for data that must not be mutated after construction.
+- Do not use `Function` or `object` as a type annotation. Use the most specific callable or object type possible.
+
+## Architecture
+
+- Define explicit input and output types for all public functions and API handlers. Do not rely on
+  inferred return types at public API boundaries.
+- Validate external data (API responses, environment variables, user input) with a runtime schema
+  library (zod, io-ts) before treating it as a typed value. Validate environment variable values at
+  application startup with a typed schema. Do not access `process.env` inline throughout the
+  codebase.
+- Co-locate domain types with the module that owns them. Do not define domain types in a global or
+  shared utility file unless they are genuinely cross-cutting.
+- Do not expose internal implementation types in public module interfaces. Keep the public surface minimal.
+- Do not use type augmentation on third-party modules unless strictly necessary. Document the reason inline.
+- Use type-only imports (`import type`) when importing types that are not needed at runtime.
+- Do not mutate function arguments. Prefer readonly arrays and readonly object types for data
+  passed across module or function boundaries.
+
+## Error Handling
+
+- Use Result/Either types or discriminated union error types for recoverable errors in library
+  code. Do not throw for control flow.
+- Do not swallow errors silently. Propagate or log with sufficient context.
+- Handle `null` and `undefined` explicitly in all code paths. Do not use the non-null assertion
+  operator (`!`) on values that could legitimately be null or undefined.
+- Define error types that carry enough context for the caller to handle them. Do not use raw
+  `Error` with only a message string for domain errors.
+- Model async operation states with explicit discriminated unions (idle, loading, success, error).
+  Do not use multiple boolean flags.
+- Annotate the return type of async functions explicitly. Do not rely on inference across async boundaries.
+
+## Testing
+
+- Write unit tests that verify type-narrowing branches produce the correct runtime behavior.

--- a/.config/opencode/skills/standards-doc/SKILL.md
+++ b/.config/opencode/skills/standards-doc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: standards-doc
 description: >-
-  Use when writing or updating documentation, instruction files, or Markdown files
-  to enforce syntax, naming, and file registry conventions.
+  Use when writing, updating, or creating any Markdown file.
+  Applies to all documentation including design docs and reports.
 ---
 
 # Doc Standards
@@ -10,23 +10,16 @@ description: >-
 ## Syntax Rules
 
 - Use Markdown headers (##) to organize sections.
-- Write content as plain sentences or bullet lists. Choose the format that best communicates each piece of information.
 - Use hyphen (-) for all bullet lists.
-- Do not use bold or italic markup.
-- Do not use tables. Use bullet lists or plain sentences instead.
-- Do not use horizontal rules (---) to separate content. Use headers to organize sections.
-- Separate sections with a blank line after each header.
-- Use Mermaid code blocks for diagrams within Design files.
-- Use TypeScript Interface code blocks for models within Design files.
-- When updating documents, overwrite existing state. Append logs only if specified.
+- Do not use bold, italic, tables, or horizontal rules.
+- Use Mermaid code blocks for diagrams.
+- Use TypeScript Interface code blocks for models.
+- When updating documents, overwrite existing state unless append is specified.
 
 ## Naming Conventions
 
-- Headers and Keys: Title Case with spaces (e.g., Syntax Rules, Package Manager, Last Run).
-- Values: Sentence case or lowercase. Use exact match only for code variables.
-- Acronyms: Standard capitalization (e.g., macOS, ARM64, WSL).
-- File Names: kebab-case with .md extension.
-- Separator: Spaces for document text, hyphens for file names.
+- Headers: Title Case with spaces.
+- File names: kebab-case with .md extension.
 
 ## File Registry
 
@@ -34,9 +27,7 @@ description: >-
   - Pattern: `[topic].md`
   - Template: [references/design.md](references/design.md)
   - Directory: `docs/design/`
-  - Example: core-beliefs.md
 - Type: Report
   - Pattern: `[YYYY-MM-DD]-[topic].md`
   - Template: [references/report.md](references/report.md)
   - Directory: `docs/reports/`
-  - Example: 2024-03-20-skill-interface-style.md

--- a/.config/opencode/skills/standards-doc/SKILL.md
+++ b/.config/opencode/skills/standards-doc/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: standards-doc
+description: >-
+  Use when writing or updating documentation, instruction files, or Markdown files
+  to enforce syntax, naming, and file registry conventions.
+---
+
+# Doc Standards
+
+## Syntax Rules
+
+- Use Markdown headers (##) to organize sections.
+- Write content as plain sentences or bullet lists. Choose the format that best communicates each piece of information.
+- Use hyphen (-) for all bullet lists.
+- Do not use bold or italic markup.
+- Do not use tables. Use bullet lists or plain sentences instead.
+- Do not use horizontal rules (---) to separate content. Use headers to organize sections.
+- Separate sections with a blank line after each header.
+- Use Mermaid code blocks for diagrams within Design files.
+- Use TypeScript Interface code blocks for models within Design files.
+- When updating documents, overwrite existing state. Append logs only if specified.
+
+## Naming Conventions
+
+- Headers and Keys: Title Case with spaces (e.g., Syntax Rules, Package Manager, Last Run).
+- Values: Sentence case or lowercase. Use exact match only for code variables.
+- Acronyms: Standard capitalization (e.g., macOS, ARM64, WSL).
+- File Names: kebab-case with .md extension.
+- Separator: Spaces for document text, hyphens for file names.
+
+## File Registry
+
+- Type: Design
+  - Pattern: `[topic].md`
+  - Template: [references/design.md](references/design.md)
+  - Directory: `docs/design/`
+  - Example: core-beliefs.md
+- Type: Report
+  - Pattern: `[YYYY-MM-DD]-[topic].md`
+  - Template: [references/report.md](references/report.md)
+  - Directory: `docs/reports/`
+  - Example: 2024-03-20-skill-interface-style.md

--- a/.config/opencode/skills/standards-doc/references/design.md
+++ b/.config/opencode/skills/standards-doc/references/design.md
@@ -1,31 +1,17 @@
-# Design: [Short Name]
+# Design: Short Name
 
-## CONTEXT
+## Context
 
-- Scope: [Feature Name / Domain]
-- Goal: [Primary Objective]
-- Status: Draft
+Scope, Goal, Status
 
-## DATA_MODEL (TypeScript)
+## Data Model
 
-```typescript
-interface Entity {
-  id: string;
-  status: "active";
-}
-```
+TypeScript Interface code block
 
-## LOGIC_FLOW (Mermaid)
+## Logic Flow
 
-```mermaid
-sequenceDiagram
-  participant Client
-  participant API
-  Client->>API: Request
-```
+Mermaid code block
 
-## INTERFACE_CONTRACT
+## Interface Contract
 
-- Endpoint: [Method] [Path]
-  - Input: { field: type }
-  - Output: { result: type }
+Endpoints with Input/Output

--- a/.config/opencode/skills/standards-doc/references/design.md
+++ b/.config/opencode/skills/standards-doc/references/design.md
@@ -1,0 +1,31 @@
+# Design: [Short Name]
+
+## CONTEXT
+
+- Scope: [Feature Name / Domain]
+- Goal: [Primary Objective]
+- Status: Draft
+
+## DATA_MODEL (TypeScript)
+
+```typescript
+interface Entity {
+  id: string;
+  status: "active";
+}
+```
+
+## LOGIC_FLOW (Mermaid)
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant API
+  Client->>API: Request
+```
+
+## INTERFACE_CONTRACT
+
+- Endpoint: [Method] [Path]
+  - Input: { field: type }
+  - Output: { result: type }

--- a/.config/opencode/skills/standards-doc/references/report.md
+++ b/.config/opencode/skills/standards-doc/references/report.md
@@ -1,0 +1,22 @@
+# Report: [Short Name]
+
+## Context
+
+- Date: [YYYY-MM-DD]
+- Scope: [Target system/component]
+- Trigger: [What initiated this investigation/work]
+
+## Investigation
+
+- Finding: [Key discovery or observation]
+- Evidence: [Log, metric, or data reference]
+
+## Resolution
+
+- Action: [What was done]
+- Result: [Outcome of the action]
+
+## Knowledge
+
+- Lesson: [Reusable insight for future reference]
+- Prevention: [How to avoid recurrence, if applicable]

--- a/.config/opencode/skills/standards-doc/references/report.md
+++ b/.config/opencode/skills/standards-doc/references/report.md
@@ -2,21 +2,16 @@
 
 ## Context
 
-- Date: [YYYY-MM-DD]
-- Scope: [Target system/component]
-- Trigger: [What initiated this investigation/work]
+Date, Scope, Trigger
 
 ## Investigation
 
-- Finding: [Key discovery or observation]
-- Evidence: [Log, metric, or data reference]
+Findings and Evidence
 
 ## Resolution
 
-- Action: [What was done]
-- Result: [Outcome of the action]
+Actions and Results
 
 ## Knowledge
 
-- Lesson: [Reusable insight for future reference]
-- Prevention: [How to avoid recurrence, if applicable]
+Lessons and Prevention

--- a/.config/opencode/skills/standards-planning/SKILL.md
+++ b/.config/opencode/skills/standards-planning/SKILL.md
@@ -1,39 +1,22 @@
 ---
 name: standards-planning
-description: >-
-  Use when creating or updating docs/planning.md to enforce template compliance,
-  lifecycle rules, and content structure.
+description: Rules for creating and managing docs/planning.md.
 ---
 
 # Planning File
 
-## Template Compliance
+## Structure
 
-- Before creating `docs/planning.md`, read [references/template.md](references/template.md) and strictly follow its structure.
-- Frontmatter has a single optional key `issue` for linking to a GitHub Issue number. No additional keys.
-- Required sections in order: `## Goal`, `## Ref`, `## Steps`, `## Verify`,
-  `## Debt`, `## Log`, `## Scratchpad`. Do not remove, rename, or reorder these sections.
-- Optional sections may be added between `## Verify` and `## Debt` when needed. Use descriptive names.
+- Before creating `docs/planning.md`, read [references/template.md](references/template.md).
+- Only one planning file exists at a time at `docs/planning.md`.
+- Add other sections freely as needed.
 
 ## Lifecycle
 
-- The planning file is an ephemeral working document. GitHub Issues are the permanent record.
-- Only one planning file exists at a time at `docs/planning.md`.
-- Update the file at each step: check off completed steps in `## Steps` and write notes in `## Scratchpad` or `## Log`.
-- Record deferred work items in `## Debt` during execution.
-- On finalize: Confirm `## Steps` reflects all completed work. Post relevant
-  findings and outcomes to the corresponding GitHub Issue as a comment.
-  Create separate GitHub Issues for each item in `## Debt`.
-- Only the user decides when a plan is complete. Do not delete `docs/planning.md` without explicit user instruction.
+1. Create: Follow template strictly.
+2. Update: Check off completed steps. Append notes to `## Log`.
+3. Finalize: Confirm `## Steps` reflects all work. Post outcomes to the GitHub Issue.
+   Create separate Issues for deferred work.
 
-## Content Rules
-
-- Goal: One sentence only.
-- Ref: List of relevant file paths. Use backtick-quoted paths.
-- Steps: Checkbox list `- [ ] Step N: ...`. One action per step.
-- Verify: Single verification command or condition.
-- Debt: List of deferred items with brief rationale. Each item should contain enough context to create a GitHub Issue.
-- Log: Append-only record of issues, corrections, decisions, and findings
-  captured during execution. Free-form bullets or subsection headers as needed.
-  Do not delete or modify existing log entries.
-- Scratchpad: Agent workspace for notes. Free-form.
+- The planning file is ephemeral. GitHub Issues are the permanent record.
+- Never delete `docs/planning.md` without explicit user instruction.

--- a/.config/opencode/skills/standards-planning/SKILL.md
+++ b/.config/opencode/skills/standards-planning/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: standards-planning
+description: >-
+  Use when creating or updating docs/planning.md to enforce template compliance,
+  lifecycle rules, and content structure.
+---
+
+# Planning File
+
+## Template Compliance
+
+- Before creating `docs/planning.md`, read [references/template.md](references/template.md) and strictly follow its structure.
+- Frontmatter has a single optional key `issue` for linking to a GitHub Issue number. No additional keys.
+- Required sections in order: `## Goal`, `## Ref`, `## Steps`, `## Verify`,
+  `## Debt`, `## Log`, `## Scratchpad`. Do not remove, rename, or reorder these sections.
+- Optional sections may be added between `## Verify` and `## Debt` when needed. Use descriptive names.
+
+## Lifecycle
+
+- The planning file is an ephemeral working document. GitHub Issues are the permanent record.
+- Only one planning file exists at a time at `docs/planning.md`.
+- Update the file at each step: check off completed steps in `## Steps` and write notes in `## Scratchpad` or `## Log`.
+- Record deferred work items in `## Debt` during execution.
+- On finalize: Confirm `## Steps` reflects all completed work. Post relevant
+  findings and outcomes to the corresponding GitHub Issue as a comment.
+  Create separate GitHub Issues for each item in `## Debt`.
+- Only the user decides when a plan is complete. Do not delete `docs/planning.md` without explicit user instruction.
+
+## Content Rules
+
+- Goal: One sentence only.
+- Ref: List of relevant file paths. Use backtick-quoted paths.
+- Steps: Checkbox list `- [ ] Step N: ...`. One action per step.
+- Verify: Single verification command or condition.
+- Debt: List of deferred items with brief rationale. Each item should contain enough context to create a GitHub Issue.
+- Log: Append-only record of issues, corrections, decisions, and findings
+  captured during execution. Free-form bullets or subsection headers as needed.
+  Do not delete or modify existing log entries.
+- Scratchpad: Agent workspace for notes. Free-form.

--- a/.config/opencode/skills/standards-planning/references/template.md
+++ b/.config/opencode/skills/standards-planning/references/template.md
@@ -1,0 +1,34 @@
+---
+issue:
+---
+
+# Planning: [Short Name]
+
+## Goal
+
+[One sentence goal]
+
+## Ref
+
+- `path/to/relevant/file`
+
+## Steps
+
+- [ ] Step 1: ...
+- [ ] Step 2: ...
+
+## Verify
+
+[Single verification command or condition]
+
+## Debt
+
+Deferred items discovered during this task. Transfer to GitHub Issues on finalize.
+
+## Log
+
+Append-only record of decisions and findings during execution.
+
+## Scratchpad
+
+Agent workspace for investigation notes.

--- a/.config/opencode/skills/standards-planning/references/template.md
+++ b/.config/opencode/skills/standards-planning/references/template.md
@@ -1,34 +1,16 @@
----
-issue:
----
-
-# Planning: [Short Name]
+# Planning: Short Name
 
 ## Goal
 
-[One sentence goal]
-
-## Ref
-
-- `path/to/relevant/file`
+One sentence only
 
 ## Steps
+
+Checkbox list. One action per step.
 
 - [ ] Step 1: ...
 - [ ] Step 2: ...
 
-## Verify
-
-[Single verification command or condition]
-
-## Debt
-
-Deferred items discovered during this task. Transfer to GitHub Issues on finalize.
-
 ## Log
 
-Append-only record of decisions and findings during execution.
-
-## Scratchpad
-
-Agent workspace for investigation notes.
+Append-only. Never delete or modify existing entries.

--- a/.config/opencode/skills/standards-tdd/SKILL.md
+++ b/.config/opencode/skills/standards-tdd/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: standards-tdd
+description: >-
+  Use when implementing new features or fixing bugs to enforce test-driven
+  development red-green-refactor workflow and anti-patterns.
+---
+
+# TDD
+
+## Iron Law
+
+Do not write production code without a failing test. No exceptions. If code is
+written before its test, delete it and start over.
+
+## Red-Green-Refactor Workflow
+
+1. Write one failing test before writing production code.
+2. Verify the test fails for the expected reason before implementation.
+3. Write the minimal production code required to make the test pass. Do not add unrelated behavior during this phase.
+4. Refactor only after tests are green. Keep behavior unchanged during refactor.
+5. Repeat the cycle for each behavior change.
+
+## Test Quality
+
+- Keep each test focused on one behavior.
+- Use test names that describe observable behavior.
+- Show intent through inputs, outputs, and side effects.
+- Test through public interfaces.
+- Do not rely on unclear names, broad setup, or multi-purpose assertions.
+
+## Anti-Patterns
+
+- Do not mock implementation details or internal calls as primary assertions.
+  Mock only external dependencies when unavoidable. Prefer observable behavior
+  over interaction-count assertions.
+- Do not test private fields, private methods, or internal data structures.
+- Do not add production methods intended only for tests.
+- Do not over-mock fast in-process dependencies.
+- Do not build excessive fixture setup that hides test intent.
+
+## Verification
+
+- Ensure every new function/method has a test.
+- Watch each test fail before implementing. Ensure each test failed for the expected reason.
+- Write minimal code to pass. Ensure all tests pass and output is pristine.
+- Ensure tests use real code and cover edge cases.
+- Do not proceed when any check is unchecked. TDD was skipped. Start over.
+
+## Exceptions
+
+TDD is not required for documentation, configuration, or non-code file edits.

--- a/.config/opencode/skills/standards-tdd/SKILL.md
+++ b/.config/opencode/skills/standards-tdd/SKILL.md
@@ -1,51 +1,27 @@
 ---
 name: standards-tdd
 description: >-
-  Use when implementing new features or fixing bugs to enforce test-driven
-  development red-green-refactor workflow and anti-patterns.
+  Use when implementing new features, fixing bugs, or writing any production code.
+  Enforces red-green-refactor workflow. Does not apply to documentation,
+  configuration, or non-code file edits.
 ---
 
 # TDD
 
 ## Iron Law
 
-Do not write production code without a failing test. No exceptions. If code is
-written before its test, delete it and start over.
+Do not write production code without a failing test. No exceptions.
+If code is written before its test, delete it and start over.
 
-## Red-Green-Refactor Workflow
+## Red-Green-Refactor
 
-1. Write one failing test before writing production code.
-2. Verify the test fails for the expected reason before implementation.
-3. Write the minimal production code required to make the test pass. Do not add unrelated behavior during this phase.
-4. Refactor only after tests are green. Keep behavior unchanged during refactor.
-5. Repeat the cycle for each behavior change.
+1. Red: Write one failing test. Verify it fails for the expected reason.
+2. Green: Write minimal production code to make it pass.
+3. Refactor: Refactor only after tests are green. Keep behavior unchanged.
+4. Repeat for each behavior change.
 
-## Test Quality
+## Rules
 
-- Keep each test focused on one behavior.
-- Use test names that describe observable behavior.
-- Show intent through inputs, outputs, and side effects.
-- Test through public interfaces.
-- Do not rely on unclear names, broad setup, or multi-purpose assertions.
-
-## Anti-Patterns
-
-- Do not mock implementation details or internal calls as primary assertions.
-  Mock only external dependencies when unavoidable. Prefer observable behavior
-  over interaction-count assertions.
-- Do not test private fields, private methods, or internal data structures.
-- Do not add production methods intended only for tests.
-- Do not over-mock fast in-process dependencies.
-- Do not build excessive fixture setup that hides test intent.
-
-## Verification
-
-- Ensure every new function/method has a test.
-- Watch each test fail before implementing. Ensure each test failed for the expected reason.
-- Write minimal code to pass. Ensure all tests pass and output is pristine.
-- Ensure tests use real code and cover edge cases.
-- Do not proceed when any check is unchecked. TDD was skipped. Start over.
-
-## Exceptions
-
-TDD is not required for documentation, configuration, or non-code file edits.
+- One behavior per test. Test through public interfaces only.
+- Do not mock internal calls. Mock only external dependencies when unavoidable.
+- Do not add production code intended only for tests.

--- a/.config/opencode/skills/subagent-first/SKILL.md
+++ b/.config/opencode/skills/subagent-first/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: subagent-first
+description: >-
+  Use when delegating tasks to sub-agents or coordinating multi-step workflows.
+---
+
+# Subagent-First
+
+## Principles
+
+- Delegate investigation, decomposition, and execution to sub-agents. Use `read`
+  and `edit` only for the planning file and session files, never for codebase files.
+- Use `ask_user` only when the user alone can answer. If investigation could resolve
+  the ambiguity, dispatch a sub-agent first.
+- Track state via `sql` and `report_intent`.
+- Dispatch independent sub-agents in parallel. Chain dependent tasks sequentially
+  using previous results.
+- When dispatching a sub-agent, always provide:
+  - Exact file paths (not full contents)
+  - Specific scope: what to do AND what NOT to do
+  - Expected output format or signal
+  - Decision authority: whether the sub-agent decides and acts, or only reports facts
+  - Both `agent_type` and `model` on every dispatch
+- When a skill is available and relevant, load it with `skill()`, then delegate
+  execution to sub-agents per the skill's instructions. Sub-agents may also invoke
+  skills directly when their task requires it.
+- If a sub-agent fails, refine the prompt once and retry. If it fails again, report
+  the failure and context to the user via `ask_user`.
+
+## Agent Type
+
+| Subtask Requirement                               | Agent Type            |
+| :------------------------------------------------ | :-------------------- |
+| Factual lookup needed ONLY for a routing decision | `explore`             |
+| Running builds, tests, lints, or installs         | `task`                |
+| Multi-step implementation requiring code edits    | `general-purpose`     |
+| Reviewing changes without modifying code          | `code-review`         |
+| Work matching a domain-specific custom agent      | use that custom agent |
+
+Always prefer the narrowest-scoped agent that can complete the subtask.
+
+`explore` returns raw data without judgment. Use ONLY when one fact is needed to
+choose which sub-agent to dispatch next. For analysis, decomposition, or planning,
+use `general-purpose`.
+
+## Model
+
+| Model                                                   | Best For                                             |
+| :------------------------------------------------------ | :--------------------------------------------------- |
+| `claude-opus-4.7` (fallback: `opus-4.6` → `sonnet-4.6`) | Default. Nuanced reasoning, review, complex refactor |
+| `claude-sonnet-4.6`                                     | Mechanical ops: git, file writes, template expansion |
+| `claude-haiku-4.5`                                      | Trivial ops: single commands, simple file reads      |
+| `gpt-5.4`                                               | Alternative perspective, second opinions             |
+
+Prefer consistency: keep the same model within a multi-step subtask.

--- a/.config/opencode/skills/subagent-first/SKILL.md
+++ b/.config/opencode/skills/subagent-first/SKILL.md
@@ -1,55 +1,51 @@
 ---
 name: subagent-first
 description: >-
-  Use when delegating tasks to sub-agents or coordinating multi-step workflows.
+  Orchestrate work by delegating to sub-agents. Main agent handles only
+  planning, judgment, and user communication. Always active for multi-step work.
 ---
 
 # Subagent-First
 
-## Principles
+## Overview
 
-- Delegate investigation, decomposition, and execution to sub-agents. Use `read`
-  and `edit` only for the planning file and session files, never for codebase files.
-- Use `ask_user` only when the user alone can answer. If investigation could resolve
-  the ambiguity, dispatch a sub-agent first.
-- Track state via `sql` and `report_intent`.
-- Dispatch independent sub-agents in parallel. Chain dependent tasks sequentially
-  using previous results.
-- When dispatching a sub-agent, always provide:
-  - Exact file paths (not full contents)
+Preserve main agent context by delegating all investigation, analysis,
+and execution to sub-agents. Main agent acts solely as orchestrator:
+planning, judgment, user communication, and state tracking.
+
+## Main Agent Boundaries
+
+- DO: plan, dispatch, judge sub-agent results, communicate with user
+- DO NOT: read or edit codebase files directly (only planning/session files)
+- Use the `question` tool only when the user alone can answer. If investigation
+  could resolve ambiguity, dispatch a sub-agent first.
+
+## Dispatch Rules
+
+- Always provide to each sub-agent:
+  - Exact file paths (not contents)
   - Specific scope: what to do AND what NOT to do
   - Expected output format or signal
-  - Decision authority: whether the sub-agent decides and acts, or only reports facts
-  - Both `agent_type` and `model` on every dispatch
-- When a skill is available and relevant, load it with `skill()`, then delegate
-  execution to sub-agents per the skill's instructions. Sub-agents may also invoke
-  skills directly when their task requires it.
-- If a sub-agent fails, refine the prompt once and retry. If it fails again, report
-  the failure and context to the user via `ask_user`.
+  - Decision authority: decide-and-act, or report-only
+- Dispatch independent sub-agents in parallel; chain dependent tasks sequentially.
+- When a skill is available, load it with the `skill` tool (passing `name` parameter) and delegate per its instructions.
+  Sub-agents may also invoke skills directly.
 
-## Agent Type
+## Model Selection
 
-| Subtask Requirement                               | Agent Type            |
-| :------------------------------------------------ | :-------------------- |
-| Factual lookup needed ONLY for a routing decision | `explore`             |
-| Running builds, tests, lints, or installs         | `task`                |
-| Multi-step implementation requiring code edits    | `general-purpose`     |
-| Reviewing changes without modifying code          | `code-review`         |
-| Work matching a domain-specific custom agent      | use that custom agent |
+- `opencode/big-pickle`: Trivial tasks: status checks, simple formatting, simple file reads
+- `github-copilot/claude-sonnet-4.6`: Default. General implementation, refactoring, analysis, code generation
+- `github-copilot/claude-sonnet-4.6`: Complex reasoning, design decisions, code review
+- `github-copilot/gemini-3.1-pro-preview`: Large-context tasks, cross-file analysis, long summarization
+- `github-copilot/gpt-5.4`: Second opinions, alternative perspectives
 
-Always prefer the narrowest-scoped agent that can complete the subtask.
+Keep the same model within a multi-step subtask.
 
-`explore` returns raw data without judgment. Use ONLY when one fact is needed to
-choose which sub-agent to dispatch next. For analysis, decomposition, or planning,
-use `general-purpose`.
+## State Tracking
 
-## Model
+Track state via the `TodoWrite` tool.
 
-| Model                                                   | Best For                                             |
-| :------------------------------------------------------ | :--------------------------------------------------- |
-| `claude-opus-4.7` (fallback: `opus-4.6` → `sonnet-4.6`) | Default. Nuanced reasoning, review, complex refactor |
-| `claude-sonnet-4.6`                                     | Mechanical ops: git, file writes, template expansion |
-| `claude-haiku-4.5`                                      | Trivial ops: single commands, simple file reads      |
-| `gpt-5.4`                                               | Alternative perspective, second opinions             |
+## Failure Handling
 
-Prefer consistency: keep the same model within a multi-step subtask.
+1. If a sub-agent fails, refine the prompt once and retry.
+2. If it fails again, report the failure and context to the user via the `question` tool.

--- a/.config/opencode/tui.jsonc
+++ b/.config/opencode/tui.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "theme": "opencode"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+Dotfiles repository for shell configuration and tool setup.
+
+## Tools
+
+- Lint: `mise run lint`
+- Format: `mise run format`
+- Test: `mise run test`

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -111,6 +111,7 @@ if type opencode >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/opencode/agents" "$HOME/.config/opencode/agents"
   create_symlink "$SCRIPT_DIR/.config/opencode/AGENTS.md" "$HOME/.config/opencode/AGENTS.md"
   create_symlink "$SCRIPT_DIR/.config/opencode/opencode.jsonc" "$HOME/.config/opencode/opencode.jsonc"
+  create_symlink "$SCRIPT_DIR/.config/opencode/skills" "$HOME/.config/opencode/skills"
   create_symlink "$SCRIPT_DIR/.config/opencode/tui.jsonc" "$HOME/.config/opencode/tui.jsonc"
 fi
 # === gpg

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -106,6 +106,13 @@ if type copilot >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.copilot/skills"
   create_symlink "$SCRIPT_DIR/.config/copilot/hooks" "$HOME/.copilot/hooks"
 fi
+# === OpenCode
+if type opencode >/dev/null 2>&1; then
+  create_symlink "$SCRIPT_DIR/.config/opencode/agents" "$HOME/.config/opencode/agents"
+  create_symlink "$SCRIPT_DIR/.config/opencode/AGENTS.md" "$HOME/.config/opencode/AGENTS.md"
+  create_symlink "$SCRIPT_DIR/.config/opencode/opencode.jsonc" "$HOME/.config/opencode/opencode.jsonc"
+  create_symlink "$SCRIPT_DIR/.config/opencode/tui.jsonc" "$HOME/.config/opencode/tui.jsonc"
+fi
 # === gpg
 if type gpg >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/gnupg/gpg-agent.conf" "$HOME/.gnupg/gpg-agent.conf"


### PR DESCRIPTION
## Related URLs

## Changes
- add opencode core configuration (opencode.jsonc, tui.jsonc, AGENTS.md)
- add agent definitions (research-expert, test-runner, triage-expert)
- add skill definitions (caveman, context-mode, gh-ops, git-commit, grill-me, standards-adr, standards-code, standards-doc, standards-planning, standards-tdd, subagent-first)
- add setup script symlink for opencode skills in aarch64 setup
- update git ignore and mise linux config

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->