### PR TITLE
feat: add Claude Code support with skills and MCP configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mise run format)",
+      "Bash(mise run lint)",
+      "Bash(mise run setup)",
+      "Bash(mise run test)"
+    ]
+  }
+}

--- a/.config/ccstatusline/settings.json
+++ b/.config/ccstatusline/settings.json
@@ -1,0 +1,98 @@
+{
+  "version": 3,
+  "lines": [
+    [
+      {
+        "id": "1",
+        "type": "model",
+        "color": "cyan"
+      },
+      {
+        "id": "2",
+        "type": "separator"
+      },
+      {
+        "id": "3",
+        "type": "context-length",
+        "color": "brightBlack"
+      },
+      {
+        "id": "4",
+        "type": "separator"
+      },
+      {
+        "id": "5",
+        "type": "tokens-cached",
+        "color": "magenta"
+      },
+      {
+        "id": "6",
+        "type": "separator"
+      },
+      {
+        "id": "7",
+        "type": "tokens-input",
+        "color": "yellow"
+      },
+      {
+        "id": "f1f100e7-6501-407e-a1c4-a062d7bb0551",
+        "type": "separator",
+        "character": "|"
+      },
+      {
+        "id": "bfd00687-8d53-428a-8d22-1292e57e2d4d",
+        "type": "tokens-output"
+      }
+    ],
+    [
+      {
+        "id": "46dc7a1c-bd72-47bc-8d1e-b493c94a5f55",
+        "type": "reset-timer"
+      },
+      {
+        "id": "2b8cc0f2-5d02-4e05-b232-d6665a00f800",
+        "type": "separator"
+      },
+      {
+        "id": "7f8b388a-95f5-415f-99c2-dc4cf917e385",
+        "type": "session-usage"
+      },
+      {
+        "id": "33d95f7b-b964-4661-b416-cb1510ad91f6",
+        "type": "separator"
+      },
+      {
+        "id": "c622b636-70bf-41c4-aa6a-fa0dbda9cdab",
+        "type": "weekly-usage"
+      }
+    ],
+    [
+      {
+        "id": "c6ae2719-144a-439f-923a-2bbea6e9a418",
+        "type": "custom-command",
+        "commandPath": "ccusage statusline",
+        "timeout": 5000,
+        "preserveColors": true
+      }
+    ]
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 2,
+  "inheritSeparatorColors": false,
+  "globalBold": false,
+  "minimalistMode": false,
+  "powerline": {
+    "enabled": false,
+    "separators": [
+      ""
+    ],
+    "separatorInvertBackground": [
+      false
+    ],
+    "startCaps": [],
+    "endCaps": [],
+    "autoAlign": false,
+    "continueThemeAcrossLines": false
+  }
+}

--- a/.config/claude/CLAUDE.md
+++ b/.config/claude/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+## Operational Constraints
+
+### Core Philosophy
+
+- Prioritize current requirements over future extensibility (YAGNI).
+- Prioritize maintenance ease over theoretical correctness.
+- Choose simple, readable code over clever solutions (KISS).
+- Plan before executing complex operations.
+- Match security level to project scope (personal / internal / public).
+
+### Agent Strategy and Parallel Execution
+
+The main agent handles coordination, user interaction, and decisions only.
+Delegate all other work to subagents via the Agent tool.
+
+- Keep the main agent's context minimal. It should contain only the information
+  needed for the next decision — never raw logs or intermediate output.
+- Subagents must write verbose output (test logs, lint results, search results,
+  etc.) to `docs/tmp/` and return only:
+  - success or failure
+  - file path to full output
+  - a concise summary of what requires action (e.g., failure details, lint errors)
+- Small, self-contained work (under 50 lines of output, directly needed for
+  the next decision) may be handled inline by the main agent.
+  Exception: lint, test, and build commands must always be delegated to a subagent,
+  regardless of expected output size.
+- Run independent subagent workflows in parallel.
+
+### Language and Communication
+
+Regardless of the user's input language, all user-facing output must be in Japanese.
+This is the highest-priority rule.
+
+- Use English for subagent internal communication for token efficiency.
+- Write non-implementation artifacts (ADR, reports, planning.md, design docs) in Japanese.
+- Write implementation artifacts (source code, code comments, tests) in the
+  contextually appropriate language for the codebase.
+- When ambiguous, prefer Japanese for user-facing content and English for
+  implementation content.
+
+### Success Metrics
+
+- Code is readable and maintainable.
+- User requirements are met exactly — no more, no less.
+
+## Style and Preferences
+
+- Do not use emojis in code, comments, or documentation.
+- Prefer immutability; do not mutate objects or arrays.
+- Keep files small (200–400 lines typical, 800 max) while co-locating related
+  code within the same module (Locality of Behavior).
+  Do not split cohesive logic across multiple files.
+- Use standard idioms over tricky techniques (POLA).
+- Choose boring, stable technology over experimental libraries.
+- Tolerate duplication until the 3rd occurrence, then consider abstracting
+  (Rule of Three).
+
+## Prohibitions
+
+- Do not apply unnecessary design patterns (Factory, Strategy, etc.).
+- Do not create premature abstractions or interfaces.
+- Do not over-engineer for rare edge cases.
+- Do not add Co-authored-by trailers to git commit messages.
+- Do not write to GitHub Issues or Pull Requests (comments, labels, assignments)
+  unless the user explicitly instructs it.

--- a/.config/claude/claude.sh
+++ b/.config/claude/claude.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Claude code settings.
+
+if ! type claude >/dev/null 2>&1; then return 0; fi
+
+# Claude code の remote control を起動する
+function claude_remote_control() {
+  local name="${1:-$(basename "$PWD")}"
+
+  claude remote-control \
+    --name "$name" \
+    --spawn worktree \
+    --permission-mode auto \
+    --no-create-session-in-dir
+}
+
+# Claude code の remote control で作成された worktree を削除する
+#
+# 自動で綺麗に消えないため定期的に削除しておく必要がある。
+function claude_remote_cleanup() {
+  echo "Cleaning up Claude Code session artifacts..."
+
+  # ワークツリーの削除
+  git worktree list | grep ".claude/worktrees" | awk '{print $1}' | while read -r wt_path; do
+    echo "Removing worktree: $wt_path"
+    # ここでは、 git lock も正常に開放されていないため強制的に削除
+    git worktree remove -f -f "$wt_path"
+  done
+
+  # 残った bridge ブランチの削除
+  git branch | grep "bridge-" | sed 's/*//g' | xargs -I {} sh -c "echo Removing branch: {}; git branch -D {}"
+
+  # git の整合性をチェック
+  git worktree prune
+  echo "Cleanup complete."
+}

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "opusplan",
+  "statusLine": {
+    "type": "command",
+    "command": "ccstatusline"
+  },
+  "extraKnownMarketplaces": {
+    "context-mode": {
+      "source": {
+        "source": "github",
+        "repo": "mksglu/context-mode"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "context-mode@context-mode": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"/home/ubuntu/.claude/hooks/context-mode-cache-heal.mjs\""
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "defaultMode": "auto",
+    "allow": [
+      "Bash(cat *)",
+      "Bash(cp *)",
+      "Bash(echo *)",
+      "Bash(find *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(git add *)",
+      "Bash(git branch *)",
+      "Bash(git checkout *)",
+      "Bash(git commit *)",
+      "Bash(git diff *)",
+      "Bash(git fetch *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git status *)",
+      "Bash(grep *)",
+      "Bash(rg *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(mv *)",
+      "Bash(pwd)",
+      "Bash(touch *)",
+      "Bash(tree *)",
+      "Read(./**)",
+      "Read(~/.claude/skills/**)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:npmjs.org)",
+      "WebSearch"
+    ],
+    "deny": [
+      "Bash(curl * | sh)",
+      "Bash(curl * | bash)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git rebase *)",
+      "Bash(git reset *)",
+      "Bash(rm -f *)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(wget * | sh)",
+      "Bash(wget * | bash)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.ssh/**)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*key*)",
+      "Read(**/*secret*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./*key*)",
+      "Read(./*secret*)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Write(**/*key*)",
+      "Write(**/*secret*)",
+      "Write(./.env)",
+      "Write(./.env.*)",
+      "Write(./*key*)",
+      "Write(./*secret*)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": true,
+    "allowUnsandboxedCommands": false,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["docker *"],
+    "filesystem": {
+      "allowWrite": ["./**", "/tmp/**", "~/.cache/**", "~/.npm/**"],
+      "denyRead": [
+        "./.env",
+        "./.env.*",
+        "~/.aws/**",
+        "~/.config/gh/**",
+        "~/.gnupg/**",
+        "~/.ssh/**"
+      ]
+    },
+    "network": {
+      "allowedDomains": [
+        "api.anthropic.com",
+        "claude.ai",
+        "*.claude.com",
+        "github.com",
+        "*.githubusercontent.com",
+        "api.github.com",
+        "objects.githubusercontent.com",
+        "registry.npmjs.org",
+        "pypi.org",
+        "files.pythonhosted.org",
+        "crates.io",
+        "*.crates.io",
+        "proxy.golang.org",
+        "sum.golang.org"
+      ]
+    }
+  }
+}

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -5,29 +5,9 @@
     "type": "command",
     "command": "ccstatusline"
   },
-  "extraKnownMarketplaces": {
-    "context-mode": {
-      "source": {
-        "source": "github",
-        "repo": "mksglu/context-mode"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "context-mode@context-mode": true
-  },
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"/home/ubuntu/.claude/hooks/context-mode-cache-heal.mjs\""
-          }
-        ]
-      }
-    ]
-  },
+  "extraKnownMarketplaces": {},
+  "enabledPlugins": {},
+  "hooks": {},
   "permissions": {
     "defaultMode": "auto",
     "allow": [
@@ -60,7 +40,16 @@
       "Read(~/.claude/skills/**)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:npmjs.org)",
-      "WebSearch"
+      "WebSearch",
+      "mcp__context-mode__ctx_batch_execute",
+      "mcp__context-mode__ctx_doctor",
+      "mcp__context-mode__ctx_execute",
+      "mcp__context-mode__ctx_execute_file",
+      "mcp__context-mode__ctx_fetch_and_index",
+      "mcp__context-mode__ctx_index",
+      "mcp__context-mode__ctx_purge",
+      "mcp__context-mode__ctx_search",
+      "mcp__context-mode__ctx_stats"
     ],
     "deny": [
       "Bash(curl * | sh)",
@@ -80,19 +69,15 @@
       "Read(~/.ssh/**)",
       "Read(**/.env)",
       "Read(**/.env.*)",
-      "Read(**/*key*)",
       "Read(**/*secret*)",
       "Read(./.env)",
       "Read(./.env.*)",
-      "Read(./*key*)",
       "Read(./*secret*)",
       "Write(**/.env)",
       "Write(**/.env.*)",
-      "Write(**/*key*)",
       "Write(**/*secret*)",
       "Write(./.env)",
       "Write(./.env.*)",
-      "Write(./*key*)",
       "Write(./*secret*)"
     ]
   },

--- a/.config/claude/skills/context-mode/SKILL.md
+++ b/.config/claude/skills/context-mode/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: context-mode
+description: >
+  Route shell, file reads, HTTP, and data analysis through context-mode MCP tools (ctx_ prefix)
+  to protect the context window. Activate when context-mode is connected or on "ctx" commands.
+metadata:
+  notes: <https://github.com/mksglu/context-mode/blob/main/configs/opencode/AGENTS.md>
+---
+
+# context-mode — MANDATORY routing rules
+
+context-mode MCP tools available. Rules protect context window from flooding. One unrouted command dumps 56 KB into context.
+
+## Think in Code — MANDATORY
+
+Analyze/count/filter/compare/search/parse/transform data:
+**write code** via `context-mode_ctx_execute(language, code)`, `console.log()` only the answer.
+Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it.
+Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`).
+`try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+
+## BLOCKED — do NOT attempt
+
+### curl / wget — BLOCKED
+
+Shell `curl`/`wget` intercepted and blocked. Do NOT retry.
+Use: `context-mode_ctx_fetch_and_index(url, source)` or
+`context-mode_ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
+
+### Inline HTTP — BLOCKED
+
+`fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, `http.request(` — intercepted. Do NOT retry.
+Use: `context-mode_ctx_execute(language, code)` — only stdout enters context
+
+### Direct web fetching — BLOCKED
+
+Use: `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)`
+
+## REDIRECTED — use sandbox
+
+### Shell (>20 lines output)
+
+Shell ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`.
+Otherwise: `context-mode_ctx_batch_execute(commands, queries)` or `context-mode_ctx_execute(language: "shell", code: "...")`
+
+### File reading (for analysis)
+
+Reading to **edit** → reading correct.
+Reading to **analyze/explore/summarize** → `context-mode_ctx_execute_file(path, language, code)`.
+
+### grep / search (large results)
+
+Use `context-mode_ctx_execute(language: "shell", code: "grep ...")` in sandbox.
+
+## Tool selection
+
+1. **GATHER**: `context-mode_ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search.
+   ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
+2. **FOLLOW-UP**: `context-mode_ctx_search(queries: ["q1", "q2", ...])` — all questions as array, ONE call.
+3. **PROCESSING**:
+   `context-mode_ctx_execute(language, code)` | `context-mode_ctx_execute_file(path, language, code)`
+   — sandbox, only stdout enters context.
+4. **WEB**:
+   `context-mode_ctx_fetch_and_index(url, source)` then `context-mode_ctx_search(queries)`
+   — raw HTML never enters context.
+5. **INDEX**: `context-mode_ctx_index(content, source)` — store in FTS5 for later search.
+
+## ctx commands
+
+| Command       | Action                                                                        |
+| ------------- | ----------------------------------------------------------------------------- |
+| `ctx stats`   | Call `stats` MCP tool, display full output verbatim                           |
+| `ctx doctor`  | Call `doctor` MCP tool, run returned shell command, display as checklist      |
+| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist     |
+| `ctx purge`   | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+
+After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.

--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gh-ops
+description: >
+  Use for GitHub operations: creating issues, posting issue comments,
+  creating draft PRs, and adding PR review comments.
+model: sonnet
+---
+
+# GitHub Operations
+
+## Global Constraints
+
+- Execute all scripts from the git repository root
+- Use only shipped scripts; do not run extra git or gh commands
+- Do NOT read the script; use it as a black box.
+- Always confirm content with the user before any write operation
+- Default language is English unless user explicitly requests otherwise
+- On script validation error or API failure: show raw error, stop
+
+## Routing
+
+- Issue Create: [`references/issue-create-rules.md`](references/issue-create-rules.md)
+- Issue Comment: [`references/issue-comment-rules.md`](references/issue-comment-rules.md)
+- PR Create: [`references/pr-create-rules.md`](references/pr-create-rules.md)
+- PR Review: [`references/pr-review-rules.md`](references/pr-review-rules.md)

--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -3,7 +3,6 @@ name: gh-ops
 description: >
   Use for GitHub operations: creating issues, posting issue comments,
   creating draft PRs, and adding PR review comments.
-model: sonnet
 ---
 
 # GitHub Operations

--- a/.config/claude/skills/gh-ops/references/issue-comment-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-comment-rules.md
@@ -1,0 +1,91 @@
+# Issue Comment Rules
+
+Post a structured comment to a GitHub Issue with a visible summary and zero or more
+collapsible details sections.
+
+## Procedure
+
+Follow these steps in order. Stop on any failure.
+
+### Step 1: Compose Content
+
+Prepare summary and details from investigation results, review findings, or incident
+analysis.
+
+Provide content as stdin JSON:
+
+```json
+{
+  "summary": "string (required, markdown)",
+  "details": [{ "label": "string", "content": "string" }]
+}
+```
+
+- `summary`: Visible summary for the comment body. Keep it self-contained so the reader
+  can understand the conclusion and next actions without expanding details.
+- `details`: Optional array of collapsible sections. Each entry requires:
+  - `label: string` – Text for the `<summary>` element
+  - `content: string` – Markdown body for the collapsible section
+
+If `details` is omitted or empty, a summary-only comment is posted.
+
+### Step 2: Confirm with User
+
+Present the composed summary and details. Proceed only after explicit approval.
+
+### Step 3: Post Comment
+
+Required flags:
+
+- `--repo OWNER/REPO` – Target repository
+- `--issue NUMBER` – Target issue number
+
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "OWNER/REPO" --issue NUMBER
+{
+  "summary": "...",
+  "details": [...]
+}
+EOF
+```
+
+The script validates the JSON, assembles the comment body, and posts it.
+On success it prints the comment URL to stdout.
+
+If the body exceeds 65536 characters, shorten the details before retrying.
+
+## Output
+
+- `url: string`: URL of the posted comment printed to stdout by the script.
+
+## Examples
+
+### Multi-Details
+
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+{
+  "summary": "## Investigation Results\n\nRoot cause identified. Creating a fix PR.",
+  "details": [
+    {
+      "label": "Log Analysis",
+      "content": "Error log details..."
+    },
+    {
+      "label": "Reproduction Steps",
+      "content": "1. Step A\n2. Step B"
+    }
+  ]
+}
+EOF
+```
+
+### Summary-Only
+
+```bash
+cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+{
+  "summary": "## Completion Report\n\nAll checks passed successfully."
+}
+EOF
+```

--- a/.config/claude/skills/gh-ops/references/issue-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-create-rules.md
@@ -1,0 +1,146 @@
+# Issue Create Rules
+
+Create a GitHub Issue with a structured body using one of two templates:
+product-backlog (parent issue) or feature (work item).
+
+## Procedure
+
+Follow these steps in order. Stop on any failure.
+
+### Step 1: Determine Type
+
+Select one based on intent:
+
+- `product-backlog` – Parent issue defining a product goal and its scope. Contains
+  overview, details, goal, and notes sections.
+- `feature` – Work item issue linked to a product backlog. Contains related URLs, goal,
+  and details sections.
+
+Ask the user which type to create. Infer from context when intent is clear.
+
+### Step 2: Compose Content
+
+Prepare title and body fields based on the selected template. See Body Templates below.
+
+Provide content as stdin JSON:
+
+```json
+{
+  "title": "string (required)",
+  "overview": "string (product-backlog only)",
+  "details": "string",
+  "goal": "string",
+  "notes": "string (product-backlog only)",
+  "related_urls": "string (feature only)"
+}
+```
+
+### Step 3: Confirm with User
+
+Present the composed issue content. Proceed only after explicit approval.
+
+### Step 4: Create Issue
+
+Required flags:
+
+- `--type` – Issue type from Step 1
+
+Optional flags:
+
+- `--repo OWNER/REPO` – Target repository (defaults to current repository)
+- `--labels` – Comma-separated labels
+- `--assignees` – Comma-separated assignees
+- `--project` – Project name
+
+Recommended JSON fields per type:
+
+- `product-backlog`: `title` (required), `overview`, `details`, `goal`, `notes`
+- `feature`: `title` (required), `related_urls`, `goal`, `details`
+
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type <type> [optional flags]
+{
+  "title": "...",
+  ...
+}
+EOF
+```
+
+The script validates the JSON, builds the body from the template, and creates the
+issue via `gh issue create`. On success it prints the issue URL to stdout.
+
+## Body Templates
+
+### Product Backlog Body Template
+
+The script builds the product-backlog issue body from this section structure.
+Each {field} is replaced with the corresponding JSON input value.
+Sections with empty content include only the header.
+
+```markdown
+## Overview
+
+{overview}
+
+## Details
+
+{details}
+
+## Goal
+
+{goal}
+
+## Notes
+
+{notes}
+```
+
+### Feature Body Template
+
+The script builds the feature issue body from this section structure.
+Each {field} is replaced with the corresponding JSON input value.
+Sections with empty content include only the header.
+
+```markdown
+## Related URLs
+
+{related_urls}
+
+## Goal
+
+{goal}
+
+## Details
+
+{details}
+```
+
+## Output
+
+- `url: string`: URL of the created issue printed to stdout by the script.
+- With `--json`: `{ "number": number, "url": string }`.
+
+## Examples
+
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type product-backlog --labels "backlog"
+{
+  "title": "User authentication system",
+  "overview": "Implement user authentication to support login and registration flows.",
+  "details": "Use OAuth 2.0 with JWT tokens for session management.",
+  "goal": "Users can sign up, log in, and maintain authenticated sessions.",
+  "notes": "Consider rate limiting for login endpoints."
+}
+EOF
+```
+
+```bash
+cat <<'EOF' | bash scripts/create-issue.sh --type feature --repo "owner/repo" --labels "feature" --assignees "@me"
+{
+  "title": "Implement login endpoint",
+  "related_urls": "- parent: #42",
+  "goal": "POST /api/login returns a valid JWT token for correct credentials.",
+  "details": "Validate email and password against the user store. Return 401 for invalid credentials."
+}
+EOF
+```

--- a/.config/claude/skills/gh-ops/references/pr-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-create-rules.md
@@ -1,0 +1,128 @@
+# PR Create Rules
+
+Create a draft pull request with a Conventional Commits-style title and
+standardized body.
+
+## Procedure
+
+Follow these steps in order. Stop on any failure.
+
+### Step 1: Check Branch Status
+
+Run `bash scripts/check-branch-status.sh [--base <branch>]`.
+Inspects uncommitted changes, commit history, and diff statistics.
+Abort if no commits differ from the base branch.
+
+### Step 2: Determine PR Type
+
+Select one based on the changes:
+
+- `build` – Build system or external dependency changes
+- `chore` – Maintenance tasks, scripts, config
+- `ci` – CI configuration and scripts
+- `docs` – Documentation changes
+- `feat` – New features
+- `fix` – Bug fixes
+- `i18n` – Internationalization
+- `perf` – Performance improvements
+- `refactor` – Code refactoring
+- `revert` – Revert previous commits
+- `style` – Code style changes (formatting, whitespace)
+- `test` – Test additions or corrections
+
+### Step 3: Compose Title
+
+Format: imperative mood, concise, no trailing period, no file paths.
+
+- Good: `"clarify PR draft skill"`, `"resolve token expiration"`
+- Bad: `"clarified the PR draft skill."`, `"update src/auth/token.ts"`
+
+### Step 4: Compose Body Content
+
+Required flags:
+
+- `--type` – PR type from Step 2
+- `--title` – Title from Step 3
+- `--changes` – Bullet lines starting with `-`
+
+Optional flags:
+
+- `--related-urls` – Related issue/PR URLs
+- `--confirmation` – Verification steps performed
+- `--review-points` – Areas needing reviewer attention
+- `--limitations` – Known limitations or follow-up needed
+- `--additional` – Any extra context
+- `--base` – Base branch (default: repo default branch)
+
+### Step 5: Confirm with User
+
+Present the composed title, type, and body content. Proceed only after explicit
+approval.
+
+### Step 6: Create Draft PR
+
+```bash
+bash scripts/create-pr.sh \
+  --type <type> \
+  --title "<title>" \
+  --changes "<bullet lines>" \
+  [--related-urls "<urls>"] \
+  [--confirmation "<results>"] \
+  [--review-points "<points>"] \
+  [--limitations "<limitations>"] \
+  [--additional "<context>"] \
+  [--base <branch>]
+```
+
+The script validates type and required parameters. Abort on validation errors.
+
+## PR Body Format
+
+```markdown
+## Related URLs
+
+{related_urls}
+
+## Changes
+
+{changes}
+
+## Confirmation Results
+
+{confirmation_results}
+
+## Review Points
+
+{review_points}
+
+## Limitations
+
+{limitations}
+
+{additional}
+```
+
+## Examples
+
+Minimal:
+
+```bash
+bash scripts/check-branch-status.sh --base main
+bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
+  --changes "- rewrite the skill overview
+- extract the type reference
+- extract the PR body template" \
+  --base main
+```
+
+Full:
+
+```bash
+bash scripts/check-branch-status.sh
+bash scripts/create-pr.sh --type fix --title "resolve token expiration" \
+  --changes "- update token refresh logic
+- add proper error handling for expired tokens" \
+  --confirmation "- tested token refresh flow" \
+  --review-points "- token refresh timing" \
+  --limitations "- requires frontend update for new error codes"
+```

--- a/.config/claude/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-review-rules.md
@@ -1,0 +1,75 @@
+# PR Review Rules
+
+Create a pending review on a GitHub PR with inline comments via
+`scripts/create_review.sh`.
+
+## Procedure
+
+Follow these steps in order. Stop on any failure.
+
+### Step 1: Compose Comments
+
+Prepare inline comments for the review. Each comment requires:
+
+- `path: string` – File path relative to the repository root
+- `line: number` – Line number to attach the comment to
+- `body: string` – Comment body text
+
+Optional per comment:
+
+- `suggestion: string` – Code suggestion content. Do not include triple backticks;
+  the script wraps it in a GitHub suggestion block automatically.
+- `start_line: number` – Start line for multi-line comments
+- `side: "LEFT" | "RIGHT"` – Diff side
+
+Provide `--comments-json` as a valid JSON array with at least one element.
+
+### Step 2: Confirm with User
+
+Present the composed comments and summary. Proceed only after explicit approval.
+
+### Step 3: Create Review
+
+Required flags:
+
+- `--owner` – Repository owner
+- `--repo` – Repository name
+- `--pull-number` – PR number
+- `--comments-json` – JSON array of comment objects (at least one element required)
+
+Optional flags:
+
+- `--summary-body` – Review summary body text
+
+```bash
+bash scripts/create_review.sh \
+  --owner "<owner>" \
+  --repo "<repo>" \
+  --pull-number <number> \
+  --comments-json '<json array>' \
+  [--summary-body "<text>"]
+```
+
+On success, stdout contains `{ "id": {number}, "html_url": "{url}" }`.
+On failure, stderr contains an error message and the script exits non-zero.
+
+### Step 4: Do Not Submit the Review
+
+The review is created as a pending draft. Do not submit it via the CLI.
+The user will submit it manually via the GitHub UI when ready.
+
+## Output
+
+On success: `{ "id": {number}, "html_url": "{url}" }`
+
+On failure: error message on stderr, non-zero exit code.
+
+## Examples
+
+```bash
+bash scripts/create_review.sh \
+  --owner "myorg" \
+  --repo "myrepo" \
+  --pull-number 42 \
+  --comments-json '[{"path":"src/auth.py","line":42,"body":"Add null check here"}]'
+```

--- a/.config/claude/skills/gh-ops/scripts/check-branch-status.sh
+++ b/.config/claude/skills/gh-ops/scripts/check-branch-status.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Parse arguments
+BASE_BRANCH_ARG=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base)
+      BASE_BRANCH_ARG="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Usage: $0 [--base <branch>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Get current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Determine base branch
+if [[ -n "$BASE_BRANCH_ARG" ]]; then
+  BASE_BRANCH="$BASE_BRANCH_ARG"
+else
+  # Get remote HEAD branch (what origin points to as default)
+  REMOTE_HEAD_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+  if [[ -z "$REMOTE_HEAD_BRANCH" ]]; then
+    REMOTE_HEAD_BRANCH="main"
+  fi
+  BASE_BRANCH="$REMOTE_HEAD_BRANCH"
+fi
+
+echo "=== Repository Information ==="
+echo "Current branch: $CURRENT_BRANCH"
+if [[ -z "$BASE_BRANCH_ARG" ]]; then
+  echo "Remote HEAD branch: $BASE_BRANCH"
+fi
+echo "Base branch for comparison: $BASE_BRANCH"
+if [[ -z "$BASE_BRANCH_ARG" ]]; then
+  echo ""
+  echo "Note: 'gh pr create' will automatically determine the base branch"
+  echo "      based on the branch configuration and remote tracking."
+fi
+
+echo
+echo "=== Uncommitted changes ==="
+git status --short
+
+echo
+echo "=== Commit history (comparing with base: $BASE_BRANCH) ==="
+git log "$BASE_BRANCH..HEAD" --oneline || echo "No commits ahead of $BASE_BRANCH"
+
+echo
+echo "=== Diff statistics (from merge base with base branch) ==="
+git diff "$BASE_BRANCH...HEAD" --stat || echo "No differences from $BASE_BRANCH"

--- a/.config/claude/skills/gh-ops/scripts/create-issue.sh
+++ b/.config/claude/skills/gh-ops/scripts/create-issue.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: print_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  printf '%s\n' "$1" >&2
+}
+
+usage_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: usage_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r allowed_params='--type TYPE [--repo OWNER/REPO] [--labels L1,L2] [--assignees A1,A2] [--project NAME] [--json] [--dry-run]'
+
+  print_error "Error: $1"
+  print_error "Allowed parameters: $allowed_params"
+  exit 1
+}
+
+validate_input_json() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: validate_input_json expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r input_json="$1"
+  local -r validation_filter="$(
+    cat <<'JQ'
+def fail(message): message | halt_error(1);
+def require_non_empty_string(field_name):
+  if type != "string" or length == 0 then
+    fail(field_name + " must be a non-empty string")
+  else
+    .
+  end;
+def optional_string(field_name):
+  if . == null then
+    ""
+  elif type != "string" then
+    fail(field_name + " must be a string when provided")
+  else
+    .
+  end;
+
+if type != "object" then
+  fail("input must be a JSON object")
+else
+  .
+end
+| {
+    title: (.title | require_non_empty_string("title")),
+    overview: (.overview | optional_string("overview")),
+    details: (.details | optional_string("details")),
+    goal: (.goal | optional_string("goal")),
+    notes: (.notes | optional_string("notes")),
+    related_urls: (.related_urls | optional_string("related_urls"))
+  }
+JQ
+  )"
+  local validated_json
+  local error_file
+  error_file="$(mktemp)"
+
+  if validated_json="$(printf '%s' "$input_json" | jq -ce "$validation_filter" 2>"$error_file")"; then
+    rm -f -- "$error_file"
+    printf '%s' "$validated_json"
+    return 0
+  fi
+
+  local validation_error
+  validation_error="$(cat "$error_file")"
+  rm -f -- "$error_file"
+  validation_error="$(printf '%s' "$validation_error" | tr '\n' ' ' | sed -E \
+    -e 's/^jq: error \(at <stdin>:[0-9]+\): //' \
+    -e 's/^parse error: /invalid JSON: /' \
+    -e 's/[[:space:]]+$//')"
+
+  if [[ -z "$validation_error" ]]; then
+    print_error 'Error: invalid input JSON'
+  else
+    print_error "Error: $validation_error"
+  fi
+
+  return 1
+}
+
+build_body() {
+  if [[ $# -ne 2 ]]; then
+    printf '%s\n' 'Error: build_body expects exactly 2 arguments' >&2
+    return 1
+  fi
+
+  local -r validated_json="$1"
+  local -r issue_type="$2"
+  local -r body_filter="$(
+    cat <<'JQ'
+def section(header; content):
+  if content | length > 0 then
+    "## " + header + "\n\n" + content
+  else
+    "## " + header
+  end;
+
+if $type == "product-backlog" then
+  [
+    section("Overview"; .overview),
+    section("Details"; .details),
+    section("Goal"; .goal),
+    section("Notes"; .notes)
+  ] | join("\n\n")
+elif $type == "feature" then
+  [
+    section("Related URLs"; .related_urls),
+    section("Goal"; .goal),
+    section("Details"; .details)
+  ] | join("\n\n")
+else
+  "unknown type: " + $type | halt_error(1)
+end
+JQ
+  )"
+
+  printf '%s' "$validated_json" | jq -r --arg type "$issue_type" "$body_filter"
+}
+
+check_dependencies() {
+  type jq >/dev/null 2>&1 || {
+    print_error 'Error: jq is required but not found'
+    exit 1
+  }
+  type gh >/dev/null 2>&1 || {
+    print_error 'Error: gh is required but not found'
+    exit 1
+  }
+}
+
+main() {
+  check_dependencies
+
+  local issue_type=""
+  local repo=""
+  local labels=""
+  local assignees=""
+  local project=""
+  local json_output=false
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --type)
+        [[ $# -ge 2 ]] || usage_error '--type requires a value'
+        issue_type="$2"
+        shift 2
+        ;;
+      --repo)
+        [[ $# -ge 2 ]] || usage_error '--repo requires a value'
+        repo="$2"
+        shift 2
+        ;;
+      --labels)
+        [[ $# -ge 2 ]] || usage_error '--labels requires a value'
+        labels="$2"
+        shift 2
+        ;;
+      --assignees)
+        [[ $# -ge 2 ]] || usage_error '--assignees requires a value'
+        assignees="$2"
+        shift 2
+        ;;
+      --project)
+        [[ $# -ge 2 ]] || usage_error '--project requires a value'
+        project="$2"
+        shift 2
+        ;;
+      --json)
+        json_output=true
+        shift
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      *)
+        usage_error "unknown parameter: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$issue_type" ]] || usage_error '--type is required'
+  [[ "$issue_type" == "product-backlog" || "$issue_type" == "feature" ]] ||
+    usage_error '--type must be product-backlog or feature'
+  if [[ -n "$repo" ]]; then
+    [[ "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]] ||
+      usage_error '--repo must be in OWNER/REPO format'
+  fi
+
+  local input_json
+  input_json="$(cat)"
+
+  local validated_json
+  validated_json="$(validate_input_json "$input_json")"
+
+  local title
+  title="$(printf '%s' "$validated_json" | jq -r '.title')"
+
+  local body
+  body="$(build_body "$validated_json" "$issue_type")"
+
+  if [[ "$dry_run" == true ]]; then
+    printf '%s\n' '=== Preview (dry-run) ==='
+    printf '%s\n' "Type: $issue_type"
+    printf '%s\n' "Title: $title"
+    [[ -n "$repo" ]] && printf '%s\n' "Repo: $repo"
+    [[ -n "$labels" ]] && printf '%s\n' "Labels: $labels"
+    [[ -n "$assignees" ]] && printf '%s\n' "Assignees: $assignees"
+    [[ -n "$project" ]] && printf '%s\n' "Project: $project"
+    printf '%s\n' '=== Body ==='
+    printf '%s\n' "$body"
+    exit 0
+  fi
+
+  local -a gh_args=()
+  gh_args+=(--title "$title")
+  gh_args+=(--body-file -)
+
+  if [[ -n "$repo" ]]; then
+    gh_args+=(--repo "$repo")
+  fi
+
+  if [[ -n "$labels" ]]; then
+    local IFS=','
+    local -a label_array
+    read -ra label_array <<<"$labels"
+    local label
+    for label in "${label_array[@]}"; do
+      gh_args+=(--label "$label")
+    done
+  fi
+
+  if [[ -n "$assignees" ]]; then
+    local IFS=','
+    local -a assignee_array
+    read -ra assignee_array <<<"$assignees"
+    local assignee
+    for assignee in "${assignee_array[@]}"; do
+      gh_args+=(--assignee "$assignee")
+    done
+  fi
+
+  if [[ -n "$project" ]]; then
+    gh_args+=(--project "$project")
+  fi
+
+  local url
+  url="$(printf '%s\n' "$body" | gh issue create "${gh_args[@]}")"
+
+  if [[ "$json_output" == true ]]; then
+    local number
+    number="$(printf '%s' "$url" | grep -oE '[0-9]+$')"
+    printf '{"number":%s,"url":"%s"}\n' "$number" "$url"
+  else
+    printf '%s\n' "$url"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/claude/skills/gh-ops/scripts/create-pr.sh
+++ b/.config/claude/skills/gh-ops/scripts/create-pr.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Verify we're in a git repository
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Error: Not in a git repository" >&2
+  echo "Please run this script from within a git repository" >&2
+  exit 1
+fi
+
+# Allowed PR types
+ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n)
+
+# Initialize variables
+TYPE=""
+TITLE=""
+RELATED_URLS=""
+CHANGES=""
+CONFIRMATION=""
+REVIEW_POINTS=""
+LIMITATIONS=""
+ADDITIONAL=""
+BASE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    --title)
+      TITLE="$2"
+      shift 2
+      ;;
+    --related-urls)
+      RELATED_URLS="$2"
+      shift 2
+      ;;
+    --changes)
+      CHANGES="$2"
+      shift 2
+      ;;
+    --confirmation)
+      CONFIRMATION="$2"
+      shift 2
+      ;;
+    --review-points)
+      REVIEW_POINTS="$2"
+      shift 2
+      ;;
+    --limitations)
+      LIMITATIONS="$2"
+      shift 2
+      ;;
+    --additional)
+      ADDITIONAL="$2"
+      shift 2
+      ;;
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Allowed parameters: --type, --title, --related-urls, --changes, --confirmation, --review-points, --limitations, --additional, --base" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required parameters
+if [[ -z "$TYPE" ]]; then
+  echo "Error: --type is required" >&2
+  exit 1
+fi
+
+if [[ -z "$TITLE" ]]; then
+  echo "Error: --title is required" >&2
+  exit 1
+fi
+
+if [[ -z "$CHANGES" ]]; then
+  echo "Error: --changes is required" >&2
+  exit 1
+fi
+
+# Validate type
+if [[ ! " ${ALLOWED_TYPES[*]} " =~ ${TYPE} ]]; then
+  echo "Error: Invalid type '$TYPE'" >&2
+  echo "Allowed types: ${ALLOWED_TYPES[*]}" >&2
+  exit 1
+fi
+
+# Build PR title: <type>: <title>
+PR_TITLE="${TYPE}: ${TITLE}"
+
+# Build PR body
+PR_BODY="## Related URLs"
+if [[ -n "$RELATED_URLS" ]]; then
+  PR_BODY="${PR_BODY}
+${RELATED_URLS}"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Changes
+${CHANGES}
+
+## Confirmation Results"
+if [[ -n "$CONFIRMATION" ]]; then
+  PR_BODY="${PR_BODY}
+${CONFIRMATION}"
+else
+  PR_BODY="${PR_BODY}
+
+<!-- Describe preconditions, steps, and results of confirmation if any -->"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Review Points"
+if [[ -n "$REVIEW_POINTS" ]]; then
+  PR_BODY="${PR_BODY}
+${REVIEW_POINTS}"
+fi
+
+PR_BODY="${PR_BODY}
+
+## Limitations"
+if [[ -n "$LIMITATIONS" ]]; then
+  PR_BODY="${PR_BODY}
+${LIMITATIONS}"
+else
+  PR_BODY="${PR_BODY}
+
+<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->"
+fi
+
+if [[ -n "$ADDITIONAL" ]]; then
+  PR_BODY="${PR_BODY}
+
+${ADDITIONAL}"
+fi
+
+# Execute gh pr create
+if [[ -n "$BASE" ]]; then
+  gh pr create --draft --base "$BASE" --title "$PR_TITLE" --body "$PR_BODY"
+else
+  gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY"
+fi

--- a/.config/claude/skills/gh-ops/scripts/create_review.py
+++ b/.config/claude/skills/gh-ops/scripts/create_review.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+__all__ = ["main"]
+
+
+@dataclass(frozen=True)
+class ReviewResult:
+    id: int
+    html_url: str
+
+    def to_json(self) -> str:
+        return json.dumps({"id": self.id, "html_url": self.html_url})
+
+
+def extract_http_status(stderr_text: str) -> int | None:
+    match = re.search(r"HTTP\s+(\d{3})", stderr_text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def emit_error(message: str, *, exit_code: int = 1, **details: Any) -> NoReturn:
+    error_payload = {"error": message, **details}
+    print(json.dumps(error_payload), file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def main() -> None:
+    """
+    Parses arguments, constructs a JSON payload, and calls the GitHub API
+    to create a pending review.
+    """
+    parser = argparse.ArgumentParser(description="Create a pending PR review.")
+    parser.add_argument("--owner", required=True, help="Repository owner")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--pull-number", required=True, type=int, help="PR number")
+    parser.add_argument("--summary-body", required=True, help="Review summary body")
+    parser.add_argument("--comments-json", required=True, help="JSON string of comments array")
+
+    args = parser.parse_args()
+
+    try:
+        raw_comments = json.loads(args.comments_json)
+    except json.JSONDecodeError as e:
+        emit_error("invalid_comments_json", detail=f"Invalid JSON in --comments-json: {e}")
+
+    if not isinstance(raw_comments, list):
+        emit_error("invalid_comments_json", detail="--comments-json must be a JSON array")
+
+    api_comments = []
+    for index, comment in enumerate(raw_comments):
+        if not isinstance(comment, dict):
+            emit_error(
+                "invalid_comment",
+                detail=f"Comment at index {index} must be an object",
+            )
+
+        body = comment.get("body", "")
+        suggestion = comment.get("suggestion")
+        path = comment.get("path")
+        line = comment.get("line")
+        start_line = comment.get("start_line")
+        side = comment.get("side", "RIGHT")
+
+        if not path or line is None:
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} is missing required path or line",
+            )
+
+        # Append suggestion block if present
+        if suggestion:
+            if "```" in suggestion:
+                emit_error(
+                    "invalid_suggestion_content",
+                    detail=(
+                        f"Comment at index {index} suggestion must not contain triple backticks"
+                    ),
+                )
+            suggestion_block = f"\n\n```suggestion\n{suggestion}\n```"
+            body += suggestion_block
+
+        try:
+            parsed_line = int(line)
+        except (TypeError, ValueError):
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} has non-integer line: {line}",
+            )
+
+        # Construct API comment object
+        api_comment = {"path": path, "body": body, "line": parsed_line, "side": side}
+
+        if start_line:
+            try:
+                api_comment["start_line"] = int(start_line)
+            except (TypeError, ValueError):
+                emit_error(
+                    "invalid_comment_location",
+                    detail=(f"Comment at index {index} has non-integer start_line: {start_line}"),
+                )
+
+        api_comments.append(api_comment)
+
+    # Construct payload for GitHub API
+    payload = {"body": args.summary_body, "comments": api_comments}
+    # event is OMITTED to create a PENDING review
+
+    # Call gh api
+    endpoint = f"repos/{args.owner}/{args.repo}/pulls/{args.pull_number}/reviews"
+    json_payload = json.dumps(payload)
+
+    cmd = ["gh", "api", endpoint, "--method", "POST", "--input", "-"]
+
+    result = subprocess.run(cmd, input=json_payload, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        emit_error(
+            "gh_api_failed",
+            detail="Failed to create pending review via gh api",
+            exit_code=1,
+            gh_exit_code=result.returncode,
+            http_status=extract_http_status(result.stderr),
+            stderr=result.stderr.strip(),
+        )
+
+    try:
+        response_data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        emit_error(
+            "invalid_api_response",
+            detail=f"Failed to parse gh api response as JSON: {error}",
+            stdout=result.stdout.strip(),
+        )
+
+    review_id = response_data.get("id")
+    html_url = response_data.get("html_url")
+    if not isinstance(review_id, int) or not isinstance(html_url, str):
+        emit_error(
+            "invalid_api_response",
+            detail="API response missing required id or html_url fields",
+            response=response_data,
+        )
+
+    print(ReviewResult(id=review_id, html_url=html_url).to_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/claude/skills/gh-ops/scripts/create_review.sh
+++ b/.config/claude/skills/gh-ops/scripts/create_review.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the directory of this script
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! type python3 >/dev/null 2>&1; then
+  printf '%s\n' "Error: python3 is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! type gh >/dev/null 2>&1; then
+  printf '%s\n' "Error: gh is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf '%s\n' "Error: GitHub CLI is not authenticated. Run 'gh auth login' and try again." >&2
+  exit 1
+fi
+
+# Call the Python script with all arguments
+python3 "$SCRIPT_DIR/create_review.py" "$@"

--- a/.config/claude/skills/gh-ops/scripts/post-comment.sh
+++ b/.config/claude/skills/gh-ops/scripts/post-comment.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: print_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  printf '%s\n' "$1" >&2
+}
+
+usage_error() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: usage_error expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r allowed_params='--repo OWNER/REPO --issue NUMBER [--dry-run]'
+
+  print_error "Error: $1"
+  print_error "Allowed parameters: $allowed_params"
+  exit 1
+}
+
+validate_input_json() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: validate_input_json expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r input_json="$1"
+  local -r validation_filter="$(
+    cat <<'JQ'
+def fail(message): message | halt_error(1);
+def require_non_empty_string(field_name):
+  if type != "string" or length == 0 then
+    fail(field_name + " must be a non-empty string")
+  else
+    .
+  end;
+def validate_detail:
+  if type != "object" then
+    fail("details[] must be objects")
+  else
+    .
+  end
+  | {
+      label: (.label | require_non_empty_string("details[].label")),
+      content: (.content | require_non_empty_string("details[].content"))
+    }
+  | if (.label | test("[<>]")) then
+      fail("details[].label must not contain < or >")
+    else
+      .
+    end;
+
+if type != "object" then
+  fail("input must be a JSON object")
+else
+  .
+end
+| {
+    summary: (.summary | require_non_empty_string("summary")),
+    details: (
+      if .details == null then
+        []
+      elif (.details | type) != "array" then
+        fail("details must be an array when provided")
+      else
+        .details | map(validate_detail)
+      end
+    )
+  }
+JQ
+  )"
+  local validated_json
+  local validation_error
+
+  local error_file
+  error_file="$(mktemp)"
+  trap "rm -f -- '$error_file'" EXIT
+
+  if validated_json="$(printf '%s' "$input_json" | jq -ce "$validation_filter" 2>"$error_file")"; then
+    rm -f "$error_file"
+    printf '%s' "$validated_json"
+    return 0
+  fi
+
+  validation_error="$(cat "$error_file")"
+  rm -f "$error_file"
+  # Clean up jq-specific prefixes for friendlier messages (raw text used as fallback)
+  validation_error="$(printf '%s' "$validation_error" | tr '\n' ' ' | sed -E \
+    -e 's/^jq: error \(at <stdin>:[0-9]+\): //' \
+    -e 's/^parse error: /invalid JSON: /' \
+    -e 's/[[:space:]]+$//')"
+
+  if [[ -z "$validation_error" ]]; then
+    print_error 'Error: invalid input JSON'
+  else
+    print_error "Error: $validation_error"
+  fi
+
+  return 1
+}
+
+build_body() {
+  if [[ $# -ne 1 ]]; then
+    printf '%s\n' 'Error: build_body expects exactly 1 argument' >&2
+    return 1
+  fi
+
+  local -r validated_json="$1"
+  local -r body_filter="$(
+    cat <<'JQ'
+.summary + (
+  .details
+  | map("\n\n<details>\n<summary>\(.label)</summary>\n\n\(.content)\n\n</details>")
+  | join("")
+)
+JQ
+  )"
+
+  printf '%s' "$validated_json" | jq -r "$body_filter"
+}
+
+check_dependencies() {
+  type jq >/dev/null 2>&1 || {
+    print_error 'Error: jq is required but not found'
+    exit 1
+  }
+}
+
+main() {
+  check_dependencies
+
+  local repo=""
+  local issue=""
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        [[ $# -ge 2 ]] || usage_error '--repo requires a value'
+        repo="$2"
+        shift 2
+        ;;
+      --issue)
+        [[ $# -ge 2 ]] || usage_error '--issue requires a value'
+        issue="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      *)
+        usage_error "unknown parameter: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$repo" ]] || usage_error '--repo is required'
+  [[ "$repo" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]] || usage_error '--repo must be in OWNER/REPO format'
+  [[ -n "$issue" ]] || usage_error '--issue is required'
+  [[ "$issue" =~ ^[0-9]+$ ]] || usage_error '--issue must be a number'
+
+  local input_json
+  input_json="$(cat)"
+
+  local validated_json
+  validated_json="$(validate_input_json "$input_json")"
+
+  local body
+  body="$(build_body "$validated_json")"
+
+  if [[ "$dry_run" == true ]]; then
+    printf '%s\n' '=== Preview (dry-run) ==='
+    printf '%s\n' "Target: $repo#$issue"
+    printf '%s\n' '=== Body ==='
+    printf '%s\n' "$body"
+    exit 0
+  fi
+
+  printf '%s\n' "$body" | gh issue comment "$issue" --repo "$repo" --body-file -
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/claude/skills/git-commit/SKILL.md
+++ b/.config/claude/skills/git-commit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: git-commit
+description: >
+  Create a git commit from current changes.
+  Trigger on commit requests or after completing a code change task.
+model: haiku
+context: fork
+---
+
+# Git Commit
+
+## Overview
+
+Analyze the current working tree, derive a Conventional Commits 1.0.0-compliant
+message, and commit. Always execute from the git repository root.
+
+## Process
+
+### 1. Stage
+
+1. Run `git diff --staged --name-only`.
+2. If nothing staged, selectively stage only files related to the current task.
+3. If still nothing staged, abort: "no changes to commit".
+
+### 2. Analyze
+
+1. Collect diff: `git --no-pager diff --staged`.
+2. Derive type from [`references/types.md`](references/types.md).
+3. Write description: imperative English, no trailing period, ≤100 chars including type prefix.
+4. Optionally add body with `-` bullet lines.
+
+### 3. Commit
+
+Run [`scripts/commit.sh`](scripts/commit.sh) with the following options.
+Do NOT read the script; use it as a black box.
+
+- `--type <string>` (required): Commit type derived from step 2
+- `--description <string>` (required): Commit description derived from step 2
+- `--body <string>` (optional): Body text, may contain newlines
+- `--json` (required): Flag. Enables JSON output (`sha`, `message`) to stdout
+
+Example:
+
+```bash
+scripts/commit.sh \
+  --type feat \
+  --description "add user authentication endpoint" \
+  --body "- add POST /auth/login route
+- implement JWT token generation
+- add input validation middleware" \
+  --json
+```
+
+Return the JSON output as the final result.
+
+## Constraints
+
+- Abort if description is empty or is a file path.
+- Abort if type is not in [`references/types.md`](references/types.md).
+- Abort if git commit fails.

--- a/.config/claude/skills/git-commit/references/types.md
+++ b/.config/claude/skills/git-commit/references/types.md
@@ -1,0 +1,29 @@
+# Commit Type Reference
+
+Valid types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`,
+`style`, `revert`, `i18n`.
+
+- `feat`: New features
+- `fix`: Bug fixes
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Test additions or corrections
+- `chore`: Maintenance tasks, scripts, config
+- `ci`: CI configuration and scripts
+- `build`: Build system or external dependency changes
+- `perf`: Performance improvements
+- `style`: Code style changes (formatting, whitespace)
+- `revert`: Revert previous commits
+- `i18n`: Internationalization
+
+## Selection Priority
+
+When multiple types could apply, use this priority (highest first):
+
+1. Whitespace or formatting only -> `style`
+2. Only test files changed -> `test`
+3. Only documentation files changed -> `docs`
+4. Otherwise -> analyze the diff and pick the most specific type above.
+
+Choose exactly one type. Reject any type not listed. Abort with `invalid commit type`
+on mismatch.

--- a/.config/claude/skills/git-commit/scripts/commit.sh
+++ b/.config/claude/skills/git-commit/scripts/commit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Allowed commit types
+ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n)
+
+# Initialize variables
+TYPE=""
+DESCRIPTION=""
+BODY=""
+JSON_OUTPUT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    --description)
+      DESCRIPTION="$2"
+      shift 2
+      ;;
+    --body)
+      BODY="$2"
+      shift 2
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    *)
+      echo "Error: Unknown parameter '$1'" >&2
+      echo "Allowed parameters: --type, --description, --body, --json" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required parameters
+if [[ -z "$TYPE" ]]; then
+  echo "Error: --type is required" >&2
+  exit 1
+fi
+
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "Error: --description is required" >&2
+  exit 1
+fi
+
+# Normalize description
+DESCRIPTION=$(printf %s "$DESCRIPTION" | sed -E 's/[[:space:]]+$//; s/,+$//')
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "Error: --description is required" >&2
+  exit 1
+fi
+
+# Guard against accidental file-path-only descriptions
+if [[ "$DESCRIPTION" == .* && "$DESCRIPTION" == */* ]]; then
+  echo "Error: --description must be a natural-language summary, not a file path" >&2
+  exit 1
+fi
+
+# Ensure there are staged files
+if ! git diff --staged --name-only | grep -q .; then
+  echo "Error: no staged files to commit" >&2
+  exit 1
+fi
+
+# Validate type
+pattern=" ${TYPE} "
+if [[ ! " ${ALLOWED_TYPES[*]} " =~ $pattern ]]; then
+  echo "Error: Invalid type '$TYPE'" >&2
+  echo "Allowed types: ${ALLOWED_TYPES[*]}" >&2
+  exit 1
+fi
+
+# Build commit message
+COMMIT_MSG="${TYPE}: ${DESCRIPTION}"
+
+if [[ -n "$BODY" ]]; then
+  COMMIT_MSG="${COMMIT_MSG}
+
+${BODY}"
+fi
+
+# Execute git commit (redirect summary to stderr so only JSON goes to stdout)
+git commit -m "$COMMIT_MSG" >&2
+
+# Output JSON if requested
+if [[ "$JSON_OUTPUT" == true ]]; then
+  SHA="$(git rev-parse HEAD)"
+  ESCAPED_MSG="${COMMIT_MSG//\\/\\\\}"
+  ESCAPED_MSG="${ESCAPED_MSG//\"/\\\"}"
+  ESCAPED_MSG="${ESCAPED_MSG//$'\n'/\\n}"
+  printf '{"sha":"%s","message":"%s"}\n' "$SHA" "$ESCAPED_MSG"
+fi

--- a/.config/claude/skills/grill-me/SKILL.md
+++ b/.config/claude/skills/grill-me/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: grill-me
+description: Stress-test a plan or design by grilling the user with tough, methodical questions. Trigger on "grill me" or requests to challenge/critique a plan.
+metadata:
+  original: "https://github.com/mattpocock/skills/blob/main/grill-me/SKILL.md"
+---
+
+# Grill-Me
+
+Act as a relentless interviewer stress-testing the user's plan or design.
+The goal is to surface blind spots, resolve ambiguities, and reach
+a fully shared understanding before implementation.
+
+## Process
+
+1. Identify the plan/design and break it into decision branches.
+2. For each branch, ask ONE question at a time.
+   - Challenge from multiple angles: edge cases, scalability,
+     security, maintainability, trade-offs, and naming.
+   - Provide your recommended answer with reasoning.
+   - If answerable by exploring the codebase, explore instead of asking.
+3. Resolve dependencies between decisions before moving to the next branch.
+4. Continue until all branches are resolved and no open questions remain.
+   - If the user says "wrap up" or wants to skip a branch, respect it
+     and move on.

--- a/.config/claude/skills/standards-adr/SKILL.md
+++ b/.config/claude/skills/standards-adr/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: standards-adr
+description: >-
+  Use when creating or updating ADR files in docs/adr/.
+  Also use when making an architectural decision to evaluate
+  whether an ADR should be written.
+---
+
+# ADR Standards
+
+## When to Write
+
+- An AI agent asked to "clean up" the codebase would break this decision.
+- The decision was learned through a past incident or failure.
+- If a `// WHY:` inline comment alone conveys the rationale, skip the ADR.
+
+## Create
+
+1. Find the highest ID in `docs/adr/`, increment by one.
+2. Name: `NNNN-slug.md`
+3. Copy [references/template.md](references/template.md) and fill in content.
+
+## Update Status
+
+Only the user decides status changes.
+
+Permitted transitions:
+
+- `Proposed` → `Accepted` or `Rejected`
+- `Accepted` → `Deprecated` or `Superseded`
+
+On supersede: Create a new ADR with old ID in `supersedes`. Set old ADR to `Superseded`.
+On deprecate: Set old ADR to `Deprecated`.
+
+Status is the only permitted edit to an Accepted ADR.

--- a/.config/claude/skills/standards-adr/references/template.md
+++ b/.config/claude/skills/standards-adr/references/template.md
@@ -1,0 +1,23 @@
+---
+id: "0000"
+status: Proposed
+date: YYYY-MM-DD
+supersedes: []
+---
+
+# ADR-0000: Short Title
+
+> Frontmatter keys: only id, status, date, supersedes. No additions.
+> id: zero-padded 4-digit string matching filename index
+
+## Context
+
+Why this decision was needed. Background, constraints, alternatives with trade-offs.
+
+## Decision
+
+What was chosen and the rationale. Be specific.
+
+## Consequences
+
+Positive outcomes, negative trade-offs, and risks. Be honest about downsides.

--- a/.config/claude/skills/standards-code/SKILL.md
+++ b/.config/claude/skills/standards-code/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: standards-code
+description: >-
+  Use when writing or reviewing code in Bash, Go, Python, Rust, or TypeScript
+  to enforce coding standards.
+---
+
+# Coding Standards
+
+## Principles
+
+- Handle errors explicitly. Do not swallow errors silently.
+- Depend on abstractions, not concrete implementations.
+- Validate external input at the boundary. Do not trust unvalidated data beyond that point.
+- Keep public API surface minimal. Do not export internal implementation details.
+- Inject dependencies. Do not rely on global mutable state.
+- Use structured logging. Do not use print statements for operational output.
+
+## Language References
+
+- Bash: [references/bash.md](references/bash.md)
+- Go: [references/go.md](references/go.md)
+- Python: [references/python.md](references/python.md)
+- Rust: [references/rust.md](references/rust.md)
+- TypeScript: [references/typescript.md](references/typescript.md)

--- a/.config/claude/skills/standards-code/references/bash-template.sh
+++ b/.config/claude/skills/standards-code/references/bash-template.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# [Short description]
+
+set -Eeuo pipefail
+
+SCRIPT_NAME=$(basename "${0}")
+readonly SCRIPT_NAME
+
+function log_info() {
+  local message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [$SCRIPT_NAME] [INFO] $message" >&2
+}
+
+function log_err() {
+  local message="$1"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [$SCRIPT_NAME] [ERROR] $message" >&2
+}
+
+function err() {
+  log_err "Line $1: $2"
+  exit 1
+}
+
+trap 'err ${LINENO} "$BASH_COMMAND"' ERR
+
+function usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Description:
+    [Short description]
+
+OPTIONS:
+    -h, --help      Show this help message
+    -v, --verbose   Enable verbose output (set -x)
+
+EXAMPLES:
+    ${SCRIPT_NAME}
+    ${SCRIPT_NAME} --verbose
+    ${SCRIPT_NAME} --help
+EOF
+}
+
+function main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -v | --verbose)
+        set -x
+        shift
+        ;;
+      *)
+        log_err "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+
+  # Main logic here
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.config/claude/skills/standards-code/references/bash.md
+++ b/.config/claude/skills/standards-code/references/bash.md
@@ -1,0 +1,11 @@
+# Bash
+
+- Template: [references/bash-template.sh](references/bash-template.sh)
+- Pass data into functions via arguments. Do not rely on implicit global state.
+- Validate required argument counts at the start of each public function.
+- Send diagnostic messages to stderr. Return non-zero on failure.
+- Use `mktemp` for temporary files. Pass secrets via environment variables or files with mode 0600.
+- Do not use `eval` unless input is constant and defined within the same file.
+- Use `printf` for formatted output. Use `"${array[@]}"` for safe iteration.
+- Document required shell and tool assumptions at the top of the file.
+- Mock external commands in tests by overriding `PATH` with test doubles.

--- a/.config/claude/skills/standards-code/references/go.md
+++ b/.config/claude/skills/standards-code/references/go.md
@@ -1,0 +1,12 @@
+# Go
+
+- Official docs: [Effective Go](https://go.dev/doc/effective_go), [Standard Library](https://pkg.go.dev/std)
+- Pass `context.Context` as the first parameter to all blocking and IO operations.
+- Accept interfaces, return concrete types. Define interfaces at the consumer.
+- Use functional options pattern for optional configuration.
+- Wrap errors with `fmt.Errorf("...: %w", err)`. Define sentinel errors with `errors.New`.
+- Use `errors.Is` and `errors.As` for inspection. Do not compare error strings.
+- Ensure every goroutine has a clear termination path. Use `errgroup` for coordination.
+- Pre-allocate slices and maps with `make` when size is known.
+- Use `slog` for structured logging.
+- Use table-driven tests with subtests. Run tests with the race detector.

--- a/.config/claude/skills/standards-code/references/python.md
+++ b/.config/claude/skills/standards-code/references/python.md
@@ -1,0 +1,13 @@
+# Python
+
+- Official docs: [Standard Library](https://docs.python.org/3/library/index.html)
+- Use dataclasses or Pydantic models for structured data. Do not pass raw dicts across module boundaries.
+- Add type hints to all function signatures. Enable mypy strict mode for public APIs.
+- Use `Protocol` for structural typing. Prefer `Protocol` over `ABC`.
+- Define custom exception hierarchies for domain errors. Do not raise bare `Exception`.
+- Use `pathlib.Path` instead of `os.path`.
+- Do not use mutable default arguments in function signatures.
+- Use `asyncio.TaskGroup` for structured concurrency. Do not mix sync blocking calls in async functions.
+- Use parameterized queries for SQL. Do not interpolate user input.
+- Use `logging` with structured fields.
+- Use pytest with `parametrize` for edge-case coverage. Mock external I/O at service boundaries.

--- a/.config/claude/skills/standards-code/references/rust.md
+++ b/.config/claude/skills/standards-code/references/rust.md
@@ -1,0 +1,13 @@
+# Rust
+
+- Official docs: [Standard Library](https://doc.rust-lang.org/std/), [Reference](https://doc.rust-lang.org/reference/)
+- Isolate `unsafe` in dedicated abstraction layers. Document safety invariants with a SAFETY comment.
+- Return `Result` or `Option` for recoverable errors. Reserve `panic!` for invariant violations only.
+- Use `thiserror` for library crates, `anyhow` for application crates.
+- Use `?` for propagation. Implement `Display` and `Debug` for public error types.
+- Depend on trait bounds, not concrete types. Use type-state patterns for state machine invariants.
+- Prefer ownership transfer over cloning in hot paths. Prefer borrowing for read-only access.
+- Verify `Send` + `Sync` bounds for types shared across threads.
+- Use `spawn_blocking` for blocking calls in async context.
+- Commit `Cargo.lock` for binaries only. Run `cargo audit` in CI.
+- Document all public items. Fuzz parsing logic with `cargo-fuzz`.

--- a/.config/claude/skills/standards-code/references/typescript.md
+++ b/.config/claude/skills/standards-code/references/typescript.md
@@ -1,0 +1,13 @@
+# TypeScript
+
+- Official docs: [Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
+- Enable strict mode. Do not use `any` without an explicit justification comment. Use `unknown` instead.
+- Use branded types for domain primitives (IDs, monetary amounts).
+- Use discriminated unions for state machines and error types. Use exhaustive checks with `never`.
+- Use `as const` and `satisfies` for literal type inference without widening.
+- Use `Readonly<T>` and `ReadonlyArray<T>` for immutable data. Do not mutate function arguments.
+- Use `import type` for type-only imports.
+- Validate external data with a runtime schema library (zod, io-ts) at the boundary.
+- Validate environment variables at startup with a typed schema. Do not access `process.env` inline.
+- Use Result or discriminated union error types for recoverable errors. Do not throw for control flow.
+- Model async states with discriminated unions (idle, loading, success, error). Do not use boolean flags.

--- a/.config/claude/skills/standards-doc/SKILL.md
+++ b/.config/claude/skills/standards-doc/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: standards-doc
+description: >-
+  Use when writing, updating, or creating any Markdown file.
+  Applies to all documentation including design docs and reports.
+---
+
+# Doc Standards
+
+## Syntax Rules
+
+- Use Markdown headers (##) to organize sections.
+- Use hyphen (-) for all bullet lists.
+- Do not use bold, italic, tables, or horizontal rules.
+- Use Mermaid code blocks for diagrams.
+- Use TypeScript Interface code blocks for models.
+- When updating documents, overwrite existing state unless append is specified.
+
+## Naming Conventions
+
+- Headers: Title Case with spaces.
+- File names: kebab-case with .md extension.
+
+## File Registry
+
+- Type: Design
+  - Pattern: `[topic].md`
+  - Template: [references/design.md](references/design.md)
+  - Directory: `docs/design/`
+- Type: Report
+  - Pattern: `[YYYY-MM-DD]-[topic].md`
+  - Template: [references/report.md](references/report.md)
+  - Directory: `docs/reports/`

--- a/.config/claude/skills/standards-doc/references/design.md
+++ b/.config/claude/skills/standards-doc/references/design.md
@@ -1,0 +1,17 @@
+# Design: Short Name
+
+## Context
+
+Scope, Goal, Status
+
+## Data Model
+
+TypeScript Interface code block
+
+## Logic Flow
+
+Mermaid code block
+
+## Interface Contract
+
+Endpoints with Input/Output

--- a/.config/claude/skills/standards-doc/references/report.md
+++ b/.config/claude/skills/standards-doc/references/report.md
@@ -1,0 +1,17 @@
+# Report: [Short Name]
+
+## Context
+
+Date, Scope, Trigger
+
+## Investigation
+
+Findings and Evidence
+
+## Resolution
+
+Actions and Results
+
+## Knowledge
+
+Lessons and Prevention

--- a/.config/claude/skills/standards-planning/SKILL.md
+++ b/.config/claude/skills/standards-planning/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: standards-planning
+description: Rules for creating and managing docs/planning.md.
+---
+
+# Planning File
+
+## Structure
+
+- Before creating `docs/planning.md`, read [references/template.md](references/template.md).
+- Only one planning file exists at a time at `docs/planning.md`.
+- Add other sections freely as needed.
+
+## Lifecycle
+
+1. Create: Follow template strictly.
+2. Update: Check off completed steps. Append notes to `## Log`.
+3. Finalize: Confirm `## Steps` reflects all work. Post outcomes to the GitHub Issue.
+   Create separate Issues for deferred work.
+
+- The planning file is ephemeral. GitHub Issues are the permanent record.
+- Never delete `docs/planning.md` without explicit user instruction.

--- a/.config/claude/skills/standards-planning/references/template.md
+++ b/.config/claude/skills/standards-planning/references/template.md
@@ -1,0 +1,16 @@
+# Planning: Short Name
+
+## Goal
+
+One sentence only
+
+## Steps
+
+Checkbox list. One action per step.
+
+- [ ] Step 1: ...
+- [ ] Step 2: ...
+
+## Log
+
+Append-only. Never delete or modify existing entries.

--- a/.config/claude/skills/standards-tdd/SKILL.md
+++ b/.config/claude/skills/standards-tdd/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: standards-tdd
+description: >-
+  Use when implementing new features, fixing bugs, or writing any production code.
+  Enforces red-green-refactor workflow. Does not apply to documentation,
+  configuration, or non-code file edits.
+---
+
+# TDD
+
+## Iron Law
+
+Do not write production code without a failing test. No exceptions.
+If code is written before its test, delete it and start over.
+
+## Red-Green-Refactor
+
+1. Red: Write one failing test. Verify it fails for the expected reason.
+2. Green: Write minimal production code to make it pass.
+3. Refactor: Refactor only after tests are green. Keep behavior unchanged.
+4. Repeat for each behavior change.
+
+## Rules
+
+- One behavior per test. Test through public interfaces only.
+- Do not mock internal calls. Mock only external dependencies when unavoidable.
+- Do not add production code intended only for tests.

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -18,3 +18,4 @@ docs/tmp/
 
 # === claude code
 **/.claude/settings.local.json
+**/.claude/worktrees/

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -15,3 +15,6 @@ mise-tasks/
 
 # === temporary working files
 docs/tmp/
+
+# === claude code
+**/.claude/settings.local.json

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -17,6 +17,7 @@ node = "24.15.0"
 neovim = "0.12.1"
 opencode = "v1.14.21"
 "npm:@aikidosec/safe-chain" = "1.4.9"
+"npm:@anthropic-ai/sandbox-runtime" = "v0.0.49"
 "npm:@bitwarden/cli" = "2026.3.0"
 "npm:ccstatusline" = "2.2.12"                             # for claude code
 "npm:ccusage" = "v18.0.11"                                # for claude code

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -6,6 +6,7 @@ cargo-binstall = "1.18.1"
 claude = "2.1.128"
 delta = "0.19.2"
 fzf = "0.71.0"
+gemini-cli = "0.41.1"
 gh = "2.90.0"
 "github:vifm/vifm" = "v0.14.3"
 go = "1.26.2"
@@ -14,6 +15,7 @@ lazygit = "0.61.1"
 lua = "5.1.5"                                             # neovim luarocksで要求しているバージョンが5.1
 node = "24.15.0"
 neovim = "0.12.1"
+opencode = "v1.14.21"
 "npm:@aikidosec/safe-chain" = "1.4.9"
 "npm:@bitwarden/cli" = "2026.3.0"
 "npm:ccstatusline" = "2.2.12"                             # for claude code
@@ -33,7 +35,6 @@ shfmt = "3.13.1"
 ripgrep = "15.1.0"
 uv = "0.11.7"
 yq = "4.53.2"
-opencode = "v1.14.21"
 
 [env]
 ASDF_LUA_LUAROCKS_VERSION = "3.12.2" # 3.13.0 has corrupted rockspec (luarocks/luarocks#1851)

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -3,6 +3,7 @@ aws-vault = "7.2.0"
 awscli = { version = "2.34.32", symlink_bins = "true" }
 cargo-binstall = "1.18.1"
 "cargo:tree-sitter-cli" = "0.26.8"                        # for neovim
+claude = "2.1.128"
 delta = "0.19.2"
 fzf = "0.71.0"
 gh = "2.90.0"
@@ -15,6 +16,8 @@ node = "24.15.0"
 neovim = "0.12.1"
 "npm:@aikidosec/safe-chain" = "1.4.9"
 "npm:@bitwarden/cli" = "2026.3.0"
+"npm:ccstatusline" = "2.2.12"                             # for claude code
+"npm:ccusage" = "v18.0.11"                                # for claude code
 "npm:@github/copilot" = "1.0.32"
 "npm:context-mode" = "1.0.89"                             # for opencode
 "npm:mcp-remote" = "0.1.38"                               # for copilot

--- a/.config/rc-settings.sh
+++ b/.config/rc-settings.sh
@@ -28,7 +28,8 @@ if [ -n "$ZSH_VERSION" ]; then . "$_DOTFILES_CONFIG_DIR/zsh/zsh-settings.sh"; fi
 . "$_DOTFILES_CONFIG_DIR/aws-vault/aws-vault-settings.sh"
 . "$_DOTFILES_CONFIG_DIR/bitwarden/settings.sh"
 . "$_DOTFILES_CONFIG_DIR/bitwarden/settings-gui.sh"
-
+. "$_DOTFILES_CONFIG_DIR/claude/claude.sh"
+. "$_DOTFILES_CONFIG_DIR/copilot/copilot.sh"
 . "$_DOTFILES_CONFIG_DIR/fzf/fzf.bash"
 . "$_DOTFILES_CONFIG_DIR/gh/gh-settings.sh"
 . "$_DOTFILES_CONFIG_DIR/git/settings.sh"
@@ -44,10 +45,6 @@ if [ -n "$ZSH_VERSION" ]; then . "$_DOTFILES_CONFIG_DIR/zsh/zsh-settings.sh"; fi
 
 # go lang
 . "$_DOTFILES_CONFIG_DIR/go/go-settings.sh"
-# java
-# llm
-
-. "$_DOTFILES_CONFIG_DIR/copilot/copilot.sh"
 # nodejs
 . "$_DOTFILES_CONFIG_DIR/node/nvm-settings.sh"
 . "$_DOTFILES_CONFIG_DIR/node/npm.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,48 @@
 # AGENTS.md
 
-Dotfiles repository for shell configuration and tool setup.
+## Repository Overview
 
-## Tools
+Personal dotfiles repository for cross-platform shell configuration and tool setup.
+Languages: Bash, Zsh, Lua, Python (hooks/tests), TOML. No Homebrew on non-macOS environments.
+
+## Development Setup
+
+Requires [mise](https://mise.jdx.dev/).
+
+```bash
+mise run setup # install all tools
+```
+
+## Commands
 
 - Lint: `mise run lint`
 - Format: `mise run format`
 - Test: `mise run test`
+
+Run `mise run format` and `mise run lint` after any modifications.
+
+## Architecture
+
+- `.config/` — Tool configurations organized by tool name (one subdirectory per tool)
+- `.config/mise/` — Platform-specific mise tool configs
+  (`config-mac.toml`, `config-linux.toml`, `config-codespaces.toml`, etc.)
+- `.config/copilot/` — Copilot agent definitions, skills, hooks, and config
+- `.mise/` — Mise task definitions (shell scripts invoked by `mise run`)
+- `docs/` — Design documents (`docs/design/`) and ADRs
+- `tests/` — Python test suite (primarily tests for hook scripts)
+- `setup_*.sh` / `update_*.sh` — Platform-specific environment setup scripts at root
+
+## Platform Setup Scripts
+
+- Mac: `bash setup_mac.sh`
+- Linux aarch64: `bash setup_aarch64.sh` / `bash update_aarch64.sh`
+- Codespaces:`bash setup_codespaces.sh`
+- WSL: `bash setup_wsl_ubuntu.sh`
+- Termux: `bash setup_termux.sh`
+
+## CI
+
+The CI workflow (`.github/workflows/ci.yml`) only runs `mise run lint`
+and sets `MISE_IGNORED_CONFIG_PATHS` to skip platform-specific configs
+(mac, linux, colima, codespaces, termux variants) that are not available
+in the CI environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -19,6 +19,21 @@ function create_symlink() {
   ln -s "$src" "$dst"
 }
 
+# Create hardlink if link does not exist.
+function create_hardlink() {
+  local -r src=$1
+  local -r dst=$2
+
+  if [ -e "$dst" ]; then
+    echo "already exist $dst"
+    return 0
+  fi
+
+  echo "symlink $src to $dst"
+  mkdir -p "$(dirname "$dst")"
+  ln "$src" "$dst"
+}
+
 # Add loading file in .bashrc or .zshrc.
 function set_bashrc() {
   local -r filename="$1"
@@ -103,6 +118,8 @@ fi
 if type claude >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
   create_symlink "$SCRIPT_DIR/.config/claude/skills" "$HOME/.claude/skills"
+  # settings.json は sandbox を on にした場合に symlink だと bubblewrap が起動できなくなるので hard link
+  create_hardlink "$SCRIPT_DIR/.config/claude/settings.json" "$HOME/.claude/settings.json"
 
   # Setup MCP
   add_claude_mcp context-mode context-mode

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -60,17 +60,20 @@ function set_bashrc() {
 # Add Claude Code user-scope MCP server if not already configured.
 #
 # Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
+# Usage: add_claude_mcp <name> <cmd> [args...]
 function add_claude_mcp() {
   local -r name=$1
-  local -r command=$2
+  shift
 
-  if ! claude mcp get "$name" 2>&1 | grep -qF "No MCP server found"; then
+  local output
+  output=$(claude mcp get "$name" 2>&1 || true)
+  if ! echo "$output" | grep -qF "No MCP server found"; then
     echo "already exist claude mcp: $name"
     return 0
   fi
 
   echo "add claude mcp: $name"
-  claude mcp add --transport stdio --scope user "$name" "$command"
+  claude mcp add --transport stdio --scope user "$name" -- "$@"
 }
 
 # === 共通パスの設定
@@ -122,7 +125,7 @@ if type claude >/dev/null 2>&1; then
   create_hardlink "$SCRIPT_DIR/.config/claude/settings.json" "$HOME/.claude/settings.json"
 
   # Setup MCP
-  add_claude_mcp context-mode context-mode
+  add_claude_mcp context-mode sh -c "mkdir -p /tmp/claude && exec srt context-mode"
 
   if type ccstatusline >/dev/null 2>&1; then
     create_symlink "$SCRIPT_DIR/.config/ccstatusline/settings.json" "$HOME/.config/ccstatusline/settings.json"

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -42,6 +42,22 @@ function set_bashrc() {
   echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
 }
 
+# Add Claude Code user-scope MCP server if not already configured.
+#
+# Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
+function add_claude_mcp() {
+  local -r name=$1
+  local -r command=$2
+
+  if ! claude mcp get "$name" 2>&1 | grep -qF "No MCP server found"; then
+    echo "already exist claude mcp: $name"
+    return 0
+  fi
+
+  echo "add claude mcp: $name"
+  claude mcp add --transport stdio --scope user "$name" "$command"
+}
+
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -81,6 +97,18 @@ if type mise >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/mise/config-linux.toml" "$HOME/.config/mise/config.toml"
 fi
 
+# === claude
+if type claude >/dev/null 2>&1; then
+  create_symlink "$SCRIPT_DIR/.config/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+  create_symlink "$SCRIPT_DIR/.config/claude/skills" "$HOME/.claude/skills"
+
+  # Setup MCP
+  add_claude_mcp context-mode context-mode
+
+  if type ccstatusline >/dev/null 2>&1; then
+    create_symlink "$SCRIPT_DIR/.config/ccstatusline/settings.json" "$HOME/.config/ccstatusline/settings.json"
+  fi
+fi
 # === docker
 if ! type docker >/dev/null 2>&1; then
   curl -fsSL https://get.docker.com | sudo sh
@@ -96,15 +124,6 @@ if type git >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.gitconfig" "$HOME/.gitconfig"
   create_symlink "$SCRIPT_DIR/.config/git/ignore" "$HOME/.config/git/ignore"
   create_symlink "$SCRIPT_DIR/.config/git/credential-gh-helper" "$HOME/.local/bin/credential-gh-helper"
-fi
-# === github copilot cli
-if type copilot >/dev/null 2>&1; then
-  create_symlink "$SCRIPT_DIR/.config/copilot/agents" "$HOME/.copilot/agents"
-  create_symlink "$SCRIPT_DIR/.config/copilot/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"
-  create_symlink "$SCRIPT_DIR/.config/copilot/lsp-config.json" "$HOME/.copilot/lsp-config.json"
-  create_symlink "$SCRIPT_DIR/.config/copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
-  create_symlink "$SCRIPT_DIR/.config/copilot/skills" "$HOME/.copilot/skills"
-  create_symlink "$SCRIPT_DIR/.config/copilot/hooks" "$HOME/.copilot/hooks"
 fi
 # === OpenCode
 if type opencode >/dev/null 2>&1; then

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -87,6 +87,8 @@ sudo apt-get install -y --no-install-recommends gnupg pass
 sudo apt-get install -y --no-install-recommends libreadline-dev
 # mise から tree sitter cli の cargo build でパッケージが不足するため
 sudo apt-get install -y --no-install-recommends libclang-dev
+# claude code で sandbox 機能を利用するための前提条件
+sudo apt-get install -y --no-install-recommends bubblewrap socat
 
 # 各種設定ファイルの配置もしくは読み込み設定
 set_bashrc "$CONFIG_PATH/rc-settings.sh"


### PR DESCRIPTION
## Related URLs

## Changes
- Add Claude Code settings and MCP configuration (claude.sh, settings.json, .claude/settings.json)
- Add ccstatusline configuration for Claude Code status display
- Add GitHub operations skill (gh-ops) with issue/PR create and review scripts
- Add git-commit skill with Conventional Commits support
- Add standards skills (standards-code, doc, planning, TDD, ADR) and grill-me skill
- Update Linux mise config and setup_aarch64.sh for Claude Code tools
- Update AGENTS.md and CLAUDE.md with project instructions

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->