### PR TITLE
fix: fix skill script path resolution using SKILL_DIR

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -41,6 +41,8 @@
       "Read(./**)",
       "Read(~/.claude/skills/**)",
       "Read(**/.config/claude/skills/**)",
+      "Bash(**/.config/claude/skills/*/scripts/*.sh)",
+      "Bash(~/.claude/skills/*/scripts/*.sh)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:npmjs.org)",
       "WebSearch",
@@ -97,6 +99,7 @@
         "/tmp/**",
         "~/.cache/**",
         "~/.npm/**",
+        "~/.local/state/mise/trusted-configs/**",
         "~/.safe-chain/certs/ca-key.pem"
       ],
       "denyRead": [

--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -9,7 +9,9 @@ description: >
 
 ## Global Constraints
 
-- Execute all scripts from the git repository root
+- SKILL_DIR is the absolute path of the directory containing this SKILL.md;
+  derive it from the path at which Claude Code loaded this file
+- Execute all scripts using absolute paths: `bash "${SKILL_DIR}/scripts/<name>"`
 - Use only shipped scripts; do not run extra git or gh commands
 - Do NOT read the script; use it as a black box.
 - Always confirm content with the user before any write operation

--- a/.config/claude/skills/gh-ops/references/issue-comment-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-comment-rules.md
@@ -41,7 +41,7 @@ Required flags:
 - `--issue NUMBER` – Target issue number
 
 ```bash
-cat <<'EOF' | bash scripts/post-comment.sh --repo "OWNER/REPO" --issue NUMBER
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/post-comment.sh" --repo "OWNER/REPO" --issue NUMBER
 {
   "summary": "...",
   "details": [...]
@@ -63,7 +63,7 @@ If the body exceeds 65536 characters, shorten the details before retrying.
 ### Multi-Details
 
 ```bash
-cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/post-comment.sh" --repo "owner/repo" --issue 42
 {
   "summary": "## Investigation Results\n\nRoot cause identified. Creating a fix PR.",
   "details": [
@@ -83,7 +83,7 @@ EOF
 ### Summary-Only
 
 ```bash
-cat <<'EOF' | bash scripts/post-comment.sh --repo "owner/repo" --issue 42
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/post-comment.sh" --repo "owner/repo" --issue 42
 {
   "summary": "## Completion Report\n\nAll checks passed successfully."
 }

--- a/.config/claude/skills/gh-ops/references/issue-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-create-rules.md
@@ -58,7 +58,7 @@ Recommended JSON fields per type:
 - `feature`: `title` (required), `related_urls`, `goal`, `details`
 
 ```bash
-cat <<'EOF' | bash scripts/create-issue.sh --type <type> [optional flags]
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/create-issue.sh" --type <type> [optional flags]
 {
   "title": "...",
   ...
@@ -123,7 +123,7 @@ Sections with empty content include only the header.
 ## Examples
 
 ```bash
-cat <<'EOF' | bash scripts/create-issue.sh --type product-backlog --labels "backlog"
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/create-issue.sh" --type product-backlog --labels "backlog"
 {
   "title": "User authentication system",
   "overview": "Implement user authentication to support login and registration flows.",
@@ -135,7 +135,7 @@ EOF
 ```
 
 ```bash
-cat <<'EOF' | bash scripts/create-issue.sh --type feature --repo "owner/repo" --labels "feature" --assignees "@me"
+cat <<'EOF' | bash "${SKILL_DIR}/scripts/create-issue.sh" --type feature --repo "owner/repo" --labels "feature" --assignees "@me"
 {
   "title": "Implement login endpoint",
   "related_urls": "- parent: #42",

--- a/.config/claude/skills/gh-ops/references/pr-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-create-rules.md
@@ -9,7 +9,7 @@ Follow these steps in order. Stop on any failure.
 
 ### Step 1: Check Branch Status
 
-Run `bash scripts/check-branch-status.sh [--base <branch>]`.
+Run `bash "${SKILL_DIR}/scripts/check-branch-status.sh" [--base <branch>]`.
 Inspects uncommitted changes, commit history, and diff statistics.
 Abort if no commits differ from the base branch.
 
@@ -62,7 +62,7 @@ approval.
 ### Step 6: Create Draft PR
 
 ```bash
-bash scripts/create-pr.sh \
+bash "${SKILL_DIR}/scripts/create-pr.sh" \
   --type <type> \
   --title "<title>" \
   --changes "<bullet lines>" \
@@ -107,8 +107,8 @@ The script validates type and required parameters. Abort on validation errors.
 Minimal:
 
 ```bash
-bash scripts/check-branch-status.sh --base main
-bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
+bash "${SKILL_DIR}/scripts/check-branch-status.sh" --base main
+bash "${SKILL_DIR}/scripts/create-pr.sh" --type docs --title "clarify PR draft skill" \
   --changes "- rewrite the skill overview
 - extract the type reference
 - extract the PR body template" \
@@ -118,8 +118,8 @@ bash scripts/create-pr.sh --type docs --title "clarify PR draft skill" \
 Full:
 
 ```bash
-bash scripts/check-branch-status.sh
-bash scripts/create-pr.sh --type fix --title "resolve token expiration" \
+bash "${SKILL_DIR}/scripts/check-branch-status.sh"
+bash "${SKILL_DIR}/scripts/create-pr.sh" --type fix --title "resolve token expiration" \
   --changes "- update token refresh logic
 - add proper error handling for expired tokens" \
   --confirmation "- tested token refresh flow" \

--- a/.config/claude/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-review-rules.md
@@ -42,7 +42,7 @@ Optional flags:
 - `--summary-body` – Review summary body text
 
 ```bash
-bash scripts/create_review.sh \
+bash "${SKILL_DIR}/scripts/create_review.sh" \
   --owner "<owner>" \
   --repo "<repo>" \
   --pull-number <number> \
@@ -67,7 +67,7 @@ On failure: error message on stderr, non-zero exit code.
 ## Examples
 
 ```bash
-bash scripts/create_review.sh \
+bash "${SKILL_DIR}/scripts/create_review.sh" \
   --owner "myorg" \
   --repo "myrepo" \
   --pull-number 42 \

--- a/.config/claude/skills/git-commit/SKILL.md
+++ b/.config/claude/skills/git-commit/SKILL.md
@@ -14,6 +14,10 @@ context: fork
 Analyze the current working tree, derive a Conventional Commits 1.0.0-compliant
 message, and commit. Always execute from the git repository root.
 
+SKILL_DIR is the absolute path of the directory containing this SKILL.md.
+Derive it from the path at which Claude Code loaded this file.
+Use it for all script references.
+
 ## Process
 
 ### 1. Stage
@@ -31,7 +35,7 @@ message, and commit. Always execute from the git repository root.
 
 ### 3. Commit
 
-Run [`scripts/commit.sh`](scripts/commit.sh) with the following options.
+Run `bash "${SKILL_DIR}/scripts/commit.sh"` with the following options.
 Do NOT read the script; use it as a black box.
 
 - `--type <string>` (required): Commit type derived from step 2
@@ -42,7 +46,7 @@ Do NOT read the script; use it as a black box.
 Example:
 
 ```bash
-scripts/commit.sh \
+bash "${SKILL_DIR}/scripts/commit.sh" \
   --type feat \
   --description "add user authentication endpoint" \
   --body "- add POST /auth/login route

--- a/.config/sandbox-runtime/.srt-settings.json
+++ b/.config/sandbox-runtime/.srt-settings.json
@@ -28,6 +28,7 @@
       "/tmp/",
       "~/.cache/",
       "~/.claude/context-mode/",
+      "~/.local/state/mise/trusted-configs/",
       "~/.safe-chain/certs/ca-key.pem"
     ],
     "denyWrite": []

--- a/.config/sandbox-runtime/.srt-settings.json
+++ b/.config/sandbox-runtime/.srt-settings.json
@@ -26,7 +26,7 @@
     "allowWrite": [
       ".",
       "/tmp/",
-      "/tmp/claude/",
+      "~/.cache/",
       "~/.claude/context-mode/",
       "~/.safe-chain/certs/ca-key.pem"
     ],


### PR DESCRIPTION
## Related URLs

## Changes
- introduce SKILL_DIR (absolute path of the directory containing SKILL.md) to each skill
- update all script invocations to use bash "${SKILL_DIR}/scripts/<name>" form so they resolve correctly when CWD is the git root
- add Bash permissions for skill scripts to settings.json

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->