### PR TITLE
docs: clarify and restructure project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Languages: Bash, Zsh, Lua, Python (hooks/tests), TOML. No Homebrew on non-macOS 
 
 ## Development Setup
 
-Requires [mise](https://mise.jdx.dev/).
+Requires mise.
 
 ```bash
 mise run setup # install all tools
@@ -23,27 +23,26 @@ Run `mise run format` and `mise run lint` after any modifications.
 
 ## Architecture
 
-- `.config/` — Tool configurations organized by tool name (one subdirectory per tool)
-- `.config/mise/` — Platform-specific mise tool configs
-  (`config-mac.toml`, `config-linux.toml`, `config-codespaces.toml`, etc.)
-- `.config/claude/` — Claude Code agent definitions, skills, hooks, and config
-- `.config/copilot/` — Copilot agent definitions, skills, hooks, and config
-- `.mise/` — Mise task definitions (shell scripts invoked by `mise run`)
-- `docs/` — Design documents and ADRs
-- `tests/` — Python test suite (primarily tests for hook scripts)
-- `setup_*.sh` / `update_*.sh` — Platform-specific environment setup scripts at root
+- `.config/`: Tool configurations organized by tool name (one subdirectory per tool)
+  - `.config/mise/`: Platform-specific mise tool configs; each `setup_*.sh` symlinks the
+    matching `config-{platform}.toml` to `~/.config/mise/config.toml`
+  - `.config/claude/`: Claude Code user settings managed as dotfiles (CLAUDE.md, skills/,
+    settings.json); distinct from `.claude/` (runtime directory used by the Claude Code process)
+  - `.config/copilot/`: Copilot agent definitions, skills, hooks, and config
+  - Other tool configs follow the same one-directory-per-tool pattern
+- `.claude/`: Claude Code runtime directory (settings.json, agents, commands/)
+- `.mise/`: Mise task definitions (shell scripts invoked by `mise run`)
+- `docs/`: Design documents and ADRs
+- `tests/`: Python test suite (primarily tests for hook scripts)
+- `lefthook.yml`: Pre-commit hook definition (runs format → lint + test automatically)
+- `setup_*.sh` / `update_*.sh`: Platform-specific environment setup scripts at root
 
 ## Platform Setup Scripts
 
-- Mac: `bash setup_mac.sh`
-- Linux aarch64: `bash setup_aarch64.sh` / `bash update_aarch64.sh`
-- Codespaces:`bash setup_codespaces.sh`
-- WSL: `bash setup_wsl_ubuntu.sh`
-- Termux: `bash setup_termux.sh`
+Platform-specific setup scripts follow the `setup_*.sh` pattern; update scripts follow `update_*.sh`.
 
 ## CI
 
-The CI workflow (`.github/workflows/ci.yml`) only runs `mise run lint`
-and sets `MISE_IGNORED_CONFIG_PATHS` to skip platform-specific configs
-(mac, linux, colima, codespaces, termux variants) that are not available
-in the CI environment.
+The CI workflow (`.github/workflows/ci.yml`) only runs `mise run lint`.
+Platform-specific mise configs are loaded only via symlinks created by `setup_*.sh` scripts,
+so they are not present in the CI environment.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # dotfiles
 
-- Description: 各種設定ファイルを保存しています。
+各種設定ファイルを保存しています。
 
 ## 環境構築
 
-- Description: 各環境での構築はインストールスクリプトを利用して下記のように実行します。
+各環境での構築はインストールスクリプトを利用して下記のように実行します。
 
 - Mac: `bash setup_mac.sh`
 - Linux
   - aarch64: `bash setup_aarch64.sh`, `bash update_aarch64.sh`
 - Codespaces: `bash setup_codespaces.sh`
+- Colima: `bash setup_colima.sh`
 - Android/Termux:
   - termux: `bash setup_termux.sh`
   - termux + proot: `bash setup_proot_arm64.sh`
 - WSL: `bash setup_wsl_ubuntu.sh`
 
-- Description: 各環境におけるパッケージ管理について下記に記載します。
+各環境におけるパッケージ管理について下記に記載します。
 
 ### Windows
 
-- Package_Manager: [scoop](https://scoop.sh/)
-- Install:
+scoop を使用します。
+
+#### インストール
 
 ```ps1
 # scoopのインストール(詳細は公式ドキュメントを参照)
@@ -29,7 +31,7 @@ irm get.scoop.sh | iex
 scoop import .config/scoop/scoopfile.json
 ```
 
-- Export:
+#### エクスポート
 
 ```ps1
 scoop export > .config/scoop/scoopfile.json
@@ -37,25 +39,27 @@ scoop export > .config/scoop/scoopfile.json
 
 ## Development
 
-- Description: For contributors who modify this repository.
+このリポジトリを修正するコントリビューター向けの情報です。
 
 ### Setup
 
-- Requirement: [mise](https://mise.jdx.dev/)
-- Install:
+mise が必要です。
 
 ```bash
-mise install
-lefthook install
+mise run setup
 ```
+
+内部で `mise install` と `lefthook install` を実行します。
 
 ### Linting and Formatting
 
-- Description: On each commit, the following tools run automatically via lefthook.
+各コミット時に lefthook を通じて以下のツールが自動実行されます。
+
 - shfmt: Shell script formatter (`*.sh`)
 - shellcheck: Shell script linter (`*.sh`)
 - taplo: TOML formatter (`*.toml`)
 - prettier: Markdown formatter (`*.md`)
 - markdownlint-cli2: Markdown linter (`*.md`)
-- Note: Formatters apply changes automatically and re-stage the corrected files.
-  Linters will block the commit if issues are found.
+
+> Note: Formatters apply changes automatically and re-stage the corrected files.
+> Linters will block the commit if issues are found.


### PR DESCRIPTION
## Related URLs

## Changes
- rewrite README.md YAML-style bullets to natural Markdown (prose and subheadings)
- add setup_colima.sh to the environment setup list in README.md
- unify Development Setup in README.md to mise run setup
- reorganize AGENTS.md Architecture section: clarify distinction between .claude/ (runtime) and .config/claude/ (dotfiles), add symlink mechanism description for .config/mise/, consolidate remaining tool directories into one line
- change AGENTS.md Platform Setup Scripts from individual listing to pattern description
- add lefthook.yml entry to AGENTS.md Architecture section
- fix AGENTS.md CI section: remove incorrect skip-list, replace with symlink mechanism note

## Confirmation Results
- mise run format: no changes
- mise run lint: 0 errors

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->