### PR TITLE
docs: clarify git-commit skill staging process

### DIFF
--- a/.config/claude/skills/git-commit/SKILL.md
+++ b/.config/claude/skills/git-commit/SKILL.md
@@ -22,9 +22,15 @@ Use it for all script references.
 
 ### 1. Stage
 
-1. Run `git diff --staged --name-only`.
-2. If nothing staged, selectively stage only files related to the current task.
-3. If still nothing staged, abort: "no changes to commit".
+1. Run `git diff --staged --name-only` to check staged files.
+2. If nothing staged:
+   a. Run `git diff --name-only` to list unstaged tracked changes.
+   b. Run `git ls-files --others --exclude-standard` to list untracked files.
+   c. Using the conversation context (what task was just completed),
+   file paths, and diff content, identify task-related files.
+   d. Stage only the identified task-related files with `git add <file>...`.
+3. If still nothing staged, abort with an informative message that lists
+   the unstaged files found in step 2 (if any).
 
 ### 2. Analyze
 


### PR DESCRIPTION
## Related URLs

## Changes
- Add explicit `git diff --name-only` step to detect unstaged tracked changes
- Add `git ls-files --others --exclude-standard` step to detect untracked files
- Clarify that staging uses conversation context, file paths, and diff content to identify task-related files
- Improve abort message to list unstaged files when no changes can be staged

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->