### PR TITLE
feat: output JSON by default and add --no-json opt-out in git-commit skill

### DIFF
--- a/.config/claude/skills/git-commit/SKILL.md
+++ b/.config/claude/skills/git-commit/SKILL.md
@@ -46,8 +46,7 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
-- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
+- `--no-json` (optional): Flag. Disables JSON output. JSON output (`sha`, `message`) is on by default.
 
 Example:
 

--- a/.config/claude/skills/git-commit/SKILL.md
+++ b/.config/claude/skills/git-commit/SKILL.md
@@ -46,7 +46,8 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--json` (required): Flag. Enables JSON output (`sha`, `message`) to stdout
+- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
+- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
 
 Example:
 
@@ -56,8 +57,7 @@ bash "${SKILL_DIR}/scripts/commit.sh" \
   --description "add user authentication endpoint" \
   --body "- add POST /auth/login route
 - implement JWT token generation
-- add input validation middleware" \
-  --json
+- add input validation middleware"
 ```
 
 Return the JSON output as the final result.

--- a/.config/claude/skills/git-commit/scripts/commit.sh
+++ b/.config/claude/skills/git-commit/scripts/commit.sh
@@ -9,7 +9,7 @@ ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n
 TYPE=""
 DESCRIPTION=""
 BODY=""
-JSON_OUTPUT=false
+JSON_OUTPUT=true
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -30,9 +30,13 @@ while [[ $# -gt 0 ]]; do
       JSON_OUTPUT=true
       shift
       ;;
+    --no-json)
+      JSON_OUTPUT=false
+      shift
+      ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json" >&2
+      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
       exit 1
       ;;
   esac
@@ -88,7 +92,7 @@ fi
 # Execute git commit (redirect summary to stderr so only JSON goes to stdout)
 git commit -m "$COMMIT_MSG" >&2
 
-# Output JSON if requested
+# Output JSON by default (suppressed with --no-json)
 if [[ "$JSON_OUTPUT" == true ]]; then
   SHA="$(git rev-parse HEAD)"
   ESCAPED_MSG="${COMMIT_MSG//\\/\\\\}"

--- a/.config/claude/skills/git-commit/scripts/commit.sh
+++ b/.config/claude/skills/git-commit/scripts/commit.sh
@@ -26,17 +26,13 @@ while [[ $# -gt 0 ]]; do
       BODY="$2"
       shift 2
       ;;
-    --json)
-      JSON_OUTPUT=true
-      shift
-      ;;
     --no-json)
       JSON_OUTPUT=false
       shift
       ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
+      echo "Allowed parameters: --type, --description, --body, --no-json" >&2
       exit 1
       ;;
   esac

--- a/.config/copilot/skills/git-commit/SKILL.md
+++ b/.config/copilot/skills/git-commit/SKILL.md
@@ -47,7 +47,8 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--json` (required): Flag. Enables JSON output (`sha`, `message`) to stdout
+- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
+- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
 
 Example:
 
@@ -57,8 +58,7 @@ bash "${SKILL_DIR}/scripts/commit.sh" \
   --description "add user authentication endpoint" \
   --body "- add POST /auth/login route
 - implement JWT token generation
-- add input validation middleware" \
-  --json
+- add input validation middleware"
 ```
 
 Return the JSON output as the final result.

--- a/.config/copilot/skills/git-commit/SKILL.md
+++ b/.config/copilot/skills/git-commit/SKILL.md
@@ -47,8 +47,7 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
-- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
+- `--no-json` (optional): Flag. Disables JSON output. JSON output (`sha`, `message`) is on by default.
 
 Example:
 

--- a/.config/copilot/skills/git-commit/scripts/commit.sh
+++ b/.config/copilot/skills/git-commit/scripts/commit.sh
@@ -9,7 +9,7 @@ ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n
 TYPE=""
 DESCRIPTION=""
 BODY=""
-JSON_OUTPUT=false
+JSON_OUTPUT=true
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -30,9 +30,13 @@ while [[ $# -gt 0 ]]; do
       JSON_OUTPUT=true
       shift
       ;;
+    --no-json)
+      JSON_OUTPUT=false
+      shift
+      ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json" >&2
+      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
       exit 1
       ;;
   esac
@@ -88,7 +92,7 @@ fi
 # Execute git commit (redirect summary to stderr so only JSON goes to stdout)
 git commit -m "$COMMIT_MSG" >&2
 
-# Output JSON if requested
+# Output JSON by default (suppressed with --no-json)
 if [[ "$JSON_OUTPUT" == true ]]; then
   SHA="$(git rev-parse HEAD)"
   ESCAPED_MSG="${COMMIT_MSG//\\/\\\\}"

--- a/.config/copilot/skills/git-commit/scripts/commit.sh
+++ b/.config/copilot/skills/git-commit/scripts/commit.sh
@@ -26,17 +26,13 @@ while [[ $# -gt 0 ]]; do
       BODY="$2"
       shift 2
       ;;
-    --json)
-      JSON_OUTPUT=true
-      shift
-      ;;
     --no-json)
       JSON_OUTPUT=false
       shift
       ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
+      echo "Allowed parameters: --type, --description, --body, --no-json" >&2
       exit 1
       ;;
   esac

--- a/.config/opencode/skills/git-commit/SKILL.md
+++ b/.config/opencode/skills/git-commit/SKILL.md
@@ -35,7 +35,8 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--json` (required): Flag. Enables JSON output (`sha`, `message`) to stdout
+- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
+- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
 
 Example:
 
@@ -45,8 +46,7 @@ scripts/commit.sh \
   --description "add user authentication endpoint" \
   --body "- add POST /auth/login route
 - implement JWT token generation
-- add input validation middleware" \
-  --json
+- add input validation middleware"
 ```
 
 Return the JSON output as the final result.

--- a/.config/opencode/skills/git-commit/SKILL.md
+++ b/.config/opencode/skills/git-commit/SKILL.md
@@ -35,8 +35,7 @@ Do NOT read the script; use it as a black box.
 - `--type <string>` (required): Commit type derived from step 2
 - `--description <string>` (required): Commit description derived from step 2
 - `--body <string>` (optional): Body text, may contain newlines
-- `--no-json` (optional): Flag. Disables JSON output to stdout (for human/interactive use).
-- `--json` (optional): Flag. Accepted for backward compatibility. JSON output (`sha`, `message`) is on by default.
+- `--no-json` (optional): Flag. Disables JSON output. JSON output (`sha`, `message`) is on by default.
 
 Example:
 

--- a/.config/opencode/skills/git-commit/scripts/commit.sh
+++ b/.config/opencode/skills/git-commit/scripts/commit.sh
@@ -9,7 +9,7 @@ ALLOWED_TYPES=(build chore ci docs feat fix perf refactor revert style test i18n
 TYPE=""
 DESCRIPTION=""
 BODY=""
-JSON_OUTPUT=false
+JSON_OUTPUT=true
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -30,9 +30,13 @@ while [[ $# -gt 0 ]]; do
       JSON_OUTPUT=true
       shift
       ;;
+    --no-json)
+      JSON_OUTPUT=false
+      shift
+      ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json" >&2
+      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
       exit 1
       ;;
   esac
@@ -88,7 +92,7 @@ fi
 # Execute git commit (redirect summary to stderr so only JSON goes to stdout)
 git commit -m "$COMMIT_MSG" >&2
 
-# Output JSON if requested
+# Output JSON by default (suppressed with --no-json)
 if [[ "$JSON_OUTPUT" == true ]]; then
   SHA="$(git rev-parse HEAD)"
   ESCAPED_MSG="${COMMIT_MSG//\\/\\\\}"

--- a/.config/opencode/skills/git-commit/scripts/commit.sh
+++ b/.config/opencode/skills/git-commit/scripts/commit.sh
@@ -26,17 +26,13 @@ while [[ $# -gt 0 ]]; do
       BODY="$2"
       shift 2
       ;;
-    --json)
-      JSON_OUTPUT=true
-      shift
-      ;;
     --no-json)
       JSON_OUTPUT=false
       shift
       ;;
     *)
       echo "Error: Unknown parameter '$1'" >&2
-      echo "Allowed parameters: --type, --description, --body, --json, --no-json" >&2
+      echo "Allowed parameters: --type, --description, --body, --no-json" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/202

## Changes
- change commit.sh default to output JSON (all 3 platform copies)
- add --no-json flag to disable JSON output for interactive/human use
- keep --json accepted for backward compatibility
- update SKILL.md to document default-on behavior and --no-json

## Confirmation Results
- bash -n syntax check passed on all 3 scripts
- mise run lint passed (0 errors)
- mise run test passed (240 tests)
- behavior verified in isolated repos: default emits JSON, --no-json suppresses it, --json still works

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->