### PR TITLE
fix: compare against origin/<base> in check-branch-status.sh

### DIFF
--- a/.config/claude/skills/gh-ops/scripts/check-branch-status.sh
+++ b/.config/claude/skills/gh-ops/scripts/check-branch-status.sh
@@ -33,6 +33,9 @@ else
   BASE_BRANCH="$REMOTE_HEAD_BRANCH"
 fi
 
+# Use origin/<base> so comparisons work in git worktrees that have no local base branch.
+BASE_REF="origin/${BASE_BRANCH}"
+
 echo "=== Repository Information ==="
 echo "Current branch: $CURRENT_BRANCH"
 if [[ -z "$BASE_BRANCH_ARG" ]]; then
@@ -50,9 +53,9 @@ echo "=== Uncommitted changes ==="
 git status --short
 
 echo
-echo "=== Commit history (comparing with base: $BASE_BRANCH) ==="
-git log "$BASE_BRANCH..HEAD" --oneline || echo "No commits ahead of $BASE_BRANCH"
+echo "=== Commit history (comparing with base: $BASE_REF) ==="
+git log "$BASE_REF..HEAD" --oneline || echo "No commits ahead of $BASE_REF"
 
 echo
 echo "=== Diff statistics (from merge base with base branch) ==="
-git diff "$BASE_BRANCH...HEAD" --stat || echo "No differences from $BASE_BRANCH"
+git diff "$BASE_REF...HEAD" --stat || echo "No differences from $BASE_REF"

--- a/.config/copilot/skills/gh-ops/scripts/check-branch-status.sh
+++ b/.config/copilot/skills/gh-ops/scripts/check-branch-status.sh
@@ -33,6 +33,9 @@ else
   BASE_BRANCH="$REMOTE_HEAD_BRANCH"
 fi
 
+# Use origin/<base> so comparisons work in git worktrees that have no local base branch.
+BASE_REF="origin/${BASE_BRANCH}"
+
 echo "=== Repository Information ==="
 echo "Current branch: $CURRENT_BRANCH"
 if [[ -z "$BASE_BRANCH_ARG" ]]; then
@@ -50,9 +53,9 @@ echo "=== Uncommitted changes ==="
 git status --short
 
 echo
-echo "=== Commit history (comparing with base: $BASE_BRANCH) ==="
-git log "$BASE_BRANCH..HEAD" --oneline || echo "No commits ahead of $BASE_BRANCH"
+echo "=== Commit history (comparing with base: $BASE_REF) ==="
+git log "$BASE_REF..HEAD" --oneline || echo "No commits ahead of $BASE_REF"
 
 echo
 echo "=== Diff statistics (from merge base with base branch) ==="
-git diff "$BASE_BRANCH...HEAD" --stat || echo "No differences from $BASE_BRANCH"
+git diff "$BASE_REF...HEAD" --stat || echo "No differences from $BASE_REF"

--- a/.config/opencode/skills/gh-ops/scripts/check-branch-status.sh
+++ b/.config/opencode/skills/gh-ops/scripts/check-branch-status.sh
@@ -33,6 +33,9 @@ else
   BASE_BRANCH="$REMOTE_HEAD_BRANCH"
 fi
 
+# Use origin/<base> so comparisons work in git worktrees that have no local base branch.
+BASE_REF="origin/${BASE_BRANCH}"
+
 echo "=== Repository Information ==="
 echo "Current branch: $CURRENT_BRANCH"
 if [[ -z "$BASE_BRANCH_ARG" ]]; then
@@ -50,9 +53,9 @@ echo "=== Uncommitted changes ==="
 git status --short
 
 echo
-echo "=== Commit history (comparing with base: $BASE_BRANCH) ==="
-git log "$BASE_BRANCH..HEAD" --oneline || echo "No commits ahead of $BASE_BRANCH"
+echo "=== Commit history (comparing with base: $BASE_REF) ==="
+git log "$BASE_REF..HEAD" --oneline || echo "No commits ahead of $BASE_REF"
 
 echo
 echo "=== Diff statistics (from merge base with base branch) ==="
-git diff "$BASE_BRANCH...HEAD" --stat || echo "No differences from $BASE_BRANCH"
+git diff "$BASE_REF...HEAD" --stat || echo "No differences from $BASE_REF"


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/234

## Changes
- use BASE_REF=origin/${BASE_BRANCH} for the git log/diff ranges so comparison works in worktrees without a local base branch
- apply identically to the claude, copilot, and opencode gh-ops copies

## Confirmation Results
- reproduced "fatal: ambiguous argument 'master..HEAD'" before the fix; resolved after (compares against origin/master)
- mise run lint passed; the 3 copies remain byte-identical after shfmt

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->