### PR TITLE
fix: guide user to push branch before PR creation in create-pr.sh

### DIFF
--- a/.config/claude/skills/gh-ops/scripts/create-pr.sh
+++ b/.config/claude/skills/gh-ops/scripts/create-pr.sh
@@ -144,6 +144,15 @@ if [[ -n "$ADDITIONAL" ]]; then
 ${ADDITIONAL}"
 fi
 
+# Verify the current branch has been pushed to origin
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if ! git rev-parse --verify --quiet "refs/remotes/origin/${CURRENT_BRANCH}" >/dev/null 2>&1; then
+  echo "Error: current branch '${CURRENT_BRANCH}' has not been pushed to origin." >&2
+  echo "Push it first, then re-run this command:" >&2
+  echo "  git push -u origin ${CURRENT_BRANCH}" >&2
+  exit 1
+fi
+
 # Execute gh pr create
 if [[ -n "$BASE" ]]; then
   gh pr create --draft --base "$BASE" --title "$PR_TITLE" --body "$PR_BODY"


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/250

## Changes
- detect unpushed branch via missing origin remote-tracking ref before gh pr create
- abort early with branch name and explicit git push command instead of late gh error

## Confirmation Results
- unpushed branch aborts with exit 1 and a clear message (verified in isolated git repo)
- pushed branch passes the guard (verified)
- bash -n and mise run lint pass

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->