### PR TITLE
feat: support appending PR review comments when a pending review exists

### DIFF
--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -24,3 +24,5 @@ description: >
 - Issue Comment: [`references/issue-comment-rules.md`](references/issue-comment-rules.md)
 - PR Create: [`references/pr-create-rules.md`](references/pr-create-rules.md)
 - PR Review: [`references/pr-review-rules.md`](references/pr-review-rules.md)
+  (new review via `create_review.sh`; append to an existing pending review via
+  `append_review.sh`)

--- a/.config/claude/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-review-rules.md
@@ -3,6 +3,17 @@
 Create a pending review on a GitHub PR with inline comments via
 `scripts/create_review.sh`.
 
+## Choosing the Script
+
+- New review (no pending review on the PR): use `scripts/create_review.sh`.
+- A pending review already exists: use `scripts/append_review.sh` to add
+  comments to it.
+
+`create_review.sh` detects an existing pending review and aborts with
+`{"error": "pending_review_exists", "review_id": <id>}` instead of failing
+with a raw API error. When you see this, switch to `append_review.sh`, or
+submit/discard the existing review first.
+
 ## Procedure
 
 Follow these steps in order. Stop on any failure.
@@ -52,6 +63,23 @@ bash "${SKILL_DIR}/scripts/create_review.sh" \
 
 On success, stdout contains `{ "id": {number}, "html_url": "{url}" }`.
 On failure, stderr contains an error message and the script exits non-zero.
+
+If the script reports `pending_review_exists`, do not retry `create_review.sh`.
+Append the comments with `scripts/append_review.sh` instead:
+
+```bash
+bash "${SKILL_DIR}/scripts/append_review.sh" \
+  --owner "<owner>" \
+  --repo "<repo>" \
+  --pull-number <number> \
+  --comments-json '<json array>'
+```
+
+On success, stdout contains
+`{ "review_id": "<id>", "added": <count>, "thread_ids": [ ... ] }`.
+`append_review.sh` takes the same comment objects as `create_review.sh` but
+has no `--summary-body` flag. If no pending review exists it reports
+`{"error": "no_pending_review"}`; use `create_review.sh` in that case.
 
 ### Step 4: Do Not Submit the Review
 

--- a/.config/claude/skills/gh-ops/scripts/append_review.py
+++ b/.config/claude/skills/gh-ops/scripts/append_review.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any, NoReturn
+
+__all__ = ["main"]
+
+PENDING_REVIEW_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviews(first: 100, states: [PENDING]) {
+        nodes { id viewerDidAuthor }
+      }
+    }
+  }
+}
+"""
+
+ADD_THREAD_MUTATION = """
+mutation($reviewId: ID!, $path: String!, $body: String!, $line: Int!,
+         $side: DiffSide!, $startLine: Int, $startSide: DiffSide) {
+  addPullRequestReviewThread(input: {
+    pullRequestReviewId: $reviewId, path: $path, body: $body, line: $line,
+    side: $side, startLine: $startLine, startSide: $startSide
+  }) {
+    thread { id }
+  }
+}
+"""
+
+
+def emit_error(message: str, *, exit_code: int = 1, **details: Any) -> NoReturn:
+    error_payload = {"error": message, **details}
+    print(json.dumps(error_payload), file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def run_graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    payload = json.dumps({"query": query, "variables": variables})
+    cmd = ["gh", "api", "graphql", "--input", "-"]
+    result = subprocess.run(cmd, input=payload, capture_output=True, text=True)
+    if result.returncode != 0:
+        emit_error(
+            "gh_api_failed",
+            detail="Failed to call gh api graphql",
+            gh_exit_code=result.returncode,
+            stderr=result.stderr.strip(),
+        )
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        emit_error(
+            "invalid_api_response",
+            detail=f"Failed to parse graphql response as JSON: {error}",
+            stdout=result.stdout.strip(),
+        )
+    if "errors" in response:
+        emit_error("graphql_error", detail="GraphQL returned errors", errors=response["errors"])
+    data = response.get("data")
+    if not isinstance(data, dict):
+        emit_error("invalid_api_response", detail="GraphQL response missing data")
+    return data
+
+
+def find_pending_review_id(owner: str, repo: str, pull_number: int) -> str | None:
+    variables = {"owner": owner, "repo": repo, "number": pull_number}
+    data = run_graphql(PENDING_REVIEW_QUERY, variables)
+    repository = data.get("repository") or {}
+    pull_request = repository.get("pullRequest") or {}
+    nodes = (pull_request.get("reviews") or {}).get("nodes") or []
+    for review in nodes:
+        if isinstance(review, dict) and review.get("viewerDidAuthor"):
+            review_id = review.get("id")
+            if isinstance(review_id, str):
+                return review_id
+    return None
+
+
+def build_comments(comments_json: str) -> list[dict[str, Any]]:
+    try:
+        raw_comments = json.loads(comments_json)
+    except json.JSONDecodeError as error:
+        emit_error("invalid_comments_json", detail=f"Invalid JSON in --comments-json: {error}")
+    if not isinstance(raw_comments, list):
+        emit_error("invalid_comments_json", detail="--comments-json must be a JSON array")
+    comments: list[dict[str, Any]] = []
+    for index, comment in enumerate(raw_comments):
+        if not isinstance(comment, dict):
+            emit_error("invalid_comment", detail=f"Comment at index {index} must be an object")
+        body = comment.get("body", "")
+        suggestion = comment.get("suggestion")
+        path = comment.get("path")
+        line = comment.get("line")
+        start_line = comment.get("start_line")
+        side = comment.get("side", "RIGHT")
+        if not path or line is None:
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} is missing required path or line",
+            )
+        if suggestion:
+            if "```" in suggestion:
+                emit_error(
+                    "invalid_suggestion_content",
+                    detail=(
+                        f"Comment at index {index} suggestion must not contain triple backticks"
+                    ),
+                )
+            body += f"\n\n```suggestion\n{suggestion}\n```"
+        try:
+            parsed_line = int(line)
+        except (TypeError, ValueError):
+            emit_error(
+                "invalid_comment_location",
+                detail=f"Comment at index {index} has non-integer line: {line}",
+            )
+        normalized: dict[str, Any] = {"path": path, "body": body, "line": parsed_line, "side": side}
+        if start_line:
+            try:
+                normalized["start_line"] = int(start_line)
+            except (TypeError, ValueError):
+                emit_error(
+                    "invalid_comment_location",
+                    detail=(f"Comment at index {index} has non-integer start_line: {start_line}"),
+                )
+        comments.append(normalized)
+    return comments
+
+
+def thread_variables(review_id: str, comment: dict[str, Any]) -> dict[str, Any]:
+    start_line = comment.get("start_line")
+    side = comment["side"]
+    return {
+        "reviewId": review_id,
+        "path": comment["path"],
+        "body": comment["body"],
+        "line": comment["line"],
+        "side": side,
+        "startLine": start_line,
+        "startSide": side if start_line is not None else None,
+    }
+
+
+def main() -> None:
+    """Append comments to the viewer's existing pending review on a PR."""
+    parser = argparse.ArgumentParser(description="Append comments to a pending PR review.")
+    parser.add_argument("--owner", required=True, help="Repository owner")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--pull-number", required=True, type=int, help="PR number")
+    parser.add_argument("--comments-json", required=True, help="JSON string of comments array")
+
+    args = parser.parse_args()
+
+    comments = build_comments(args.comments_json)
+    if not comments:
+        emit_error(
+            "invalid_comments_json",
+            detail="--comments-json must contain at least one comment",
+        )
+
+    review_id = find_pending_review_id(args.owner, args.repo, args.pull_number)
+    if review_id is None:
+        emit_error(
+            "no_pending_review",
+            detail="No pending review found. Use create_review.sh to create one first.",
+        )
+
+    thread_ids: list[str] = []
+    for comment in comments:
+        data = run_graphql(ADD_THREAD_MUTATION, thread_variables(review_id, comment))
+        thread = (data.get("addPullRequestReviewThread") or {}).get("thread") or {}
+        thread_id = thread.get("id")
+        if not isinstance(thread_id, str):
+            emit_error("invalid_api_response", detail="Mutation response missing thread id")
+        thread_ids.append(thread_id)
+
+    print(json.dumps({"review_id": review_id, "added": len(thread_ids), "thread_ids": thread_ids}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/claude/skills/gh-ops/scripts/append_review.py
+++ b/.config/claude/skills/gh-ops/scripts/append_review.py
@@ -118,7 +118,7 @@ def build_comments(comments_json: str) -> list[dict[str, Any]]:
                 detail=f"Comment at index {index} has non-integer line: {line}",
             )
         normalized: dict[str, Any] = {"path": path, "body": body, "line": parsed_line, "side": side}
-        if start_line:
+        if start_line is not None:
             try:
                 normalized["start_line"] = int(start_line)
             except (TypeError, ValueError):
@@ -133,15 +133,17 @@ def build_comments(comments_json: str) -> list[dict[str, Any]]:
 def thread_variables(review_id: str, comment: dict[str, Any]) -> dict[str, Any]:
     start_line = comment.get("start_line")
     side = comment["side"]
-    return {
+    variables: dict[str, Any] = {
         "reviewId": review_id,
         "path": comment["path"],
         "body": comment["body"],
         "line": comment["line"],
         "side": side,
-        "startLine": start_line,
-        "startSide": side if start_line is not None else None,
     }
+    if start_line is not None:
+        variables["startLine"] = int(start_line)
+        variables["startSide"] = side
+    return variables
 
 
 def main() -> None:

--- a/.config/claude/skills/gh-ops/scripts/append_review.sh
+++ b/.config/claude/skills/gh-ops/scripts/append_review.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the directory of this script
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! type python3 >/dev/null 2>&1; then
+  printf '%s\n' "Error: python3 is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! type gh >/dev/null 2>&1; then
+  printf '%s\n' "Error: gh is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf '%s\n' "Error: GitHub CLI is not authenticated. Run 'gh auth login' and try again." >&2
+  exit 1
+fi
+
+# Call the Python script with all arguments
+python3 "$SCRIPT_DIR/append_review.py" "$@"

--- a/.config/claude/skills/gh-ops/scripts/create_review.py
+++ b/.config/claude/skills/gh-ops/scripts/create_review.py
@@ -32,6 +32,33 @@ def emit_error(message: str, *, exit_code: int = 1, **details: Any) -> NoReturn:
     sys.exit(exit_code)
 
 
+def fetch_pending_review(owner: str, repo: str, pull_number: int) -> dict[str, Any] | None:
+    endpoint = f"repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    result = subprocess.run(["gh", "api", endpoint], capture_output=True, text=True)
+    if result.returncode != 0:
+        emit_error(
+            "gh_api_failed",
+            detail="Failed to list reviews via gh api",
+            gh_exit_code=result.returncode,
+            http_status=extract_http_status(result.stderr),
+            stderr=result.stderr.strip(),
+        )
+    try:
+        reviews = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        emit_error(
+            "invalid_api_response",
+            detail=f"Failed to parse reviews response as JSON: {error}",
+            stdout=result.stdout.strip(),
+        )
+    if not isinstance(reviews, list):
+        emit_error("invalid_api_response", detail="Reviews response is not a list")
+    for review in reviews:
+        if isinstance(review, dict) and review.get("state") == "PENDING":
+            return review
+    return None
+
+
 def main() -> None:
     """
     Parses arguments, constructs a JSON payload, and calls the GitHub API
@@ -108,6 +135,17 @@ def main() -> None:
                 )
 
         api_comments.append(api_comment)
+
+    existing = fetch_pending_review(args.owner, args.repo, args.pull_number)
+    if existing is not None:
+        emit_error(
+            "pending_review_exists",
+            detail=(
+                "A pending review already exists. Use append_review.sh to add "
+                "comments to it, or submit/discard the existing review first."
+            ),
+            review_id=existing.get("id"),
+        )
 
     # Construct payload for GitHub API
     payload = {"body": args.summary_body, "comments": api_comments}

--- a/.config/claude/skills/gh-ops/scripts/create_review.py
+++ b/.config/claude/skills/gh-ops/scripts/create_review.py
@@ -125,7 +125,7 @@ def main() -> None:
         # Construct API comment object
         api_comment = {"path": path, "body": body, "line": parsed_line, "side": side}
 
-        if start_line:
+        if start_line is not None:
             try:
                 api_comment["start_line"] = int(start_line)
             except (TypeError, ValueError):

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent
@@ -24,3 +25,11 @@ _load_module(
     "config.copilot.hooks.pre_tool_use_permission",
     _PROJECT_ROOT / ".config" / "copilot" / "hooks" / "pre-tool-use-permission.py",
 )
+_gh_ops = types.ModuleType("gh_ops")
+sys.modules.setdefault("gh_ops", _gh_ops)
+
+_load_module(
+    "gh_ops.create_review",
+    _PROJECT_ROOT / ".config" / "claude" / "skills" / "gh-ops" / "scripts" / "create_review.py",
+)
+_gh_ops.create_review = sys.modules["gh_ops.create_review"]

--- a/conftest.py
+++ b/conftest.py
@@ -33,3 +33,9 @@ _load_module(
     _PROJECT_ROOT / ".config" / "claude" / "skills" / "gh-ops" / "scripts" / "create_review.py",
 )
 _gh_ops.create_review = sys.modules["gh_ops.create_review"]
+
+_load_module(
+    "gh_ops.append_review",
+    _PROJECT_ROOT / ".config" / "claude" / "skills" / "gh-ops" / "scripts" / "append_review.py",
+)
+_gh_ops.append_review = sys.modules["gh_ops.append_review"]

--- a/tests/test_append_review.py
+++ b/tests/test_append_review.py
@@ -1,0 +1,75 @@
+"""Tests for append_review.py."""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from gh_ops import append_review
+
+_COMMENTS = json.dumps([{"path": "a.py", "line": 1, "body": "x"}])
+
+
+def _argv() -> list[str]:
+    return [
+        "append_review.py",
+        "--owner",
+        "o",
+        "--repo",
+        "r",
+        "--pull-number",
+        "1",
+        "--comments-json",
+        _COMMENTS,
+    ]
+
+
+def _patch_run(monkeypatch, responses):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return responses.pop(0)
+
+    monkeypatch.setattr(append_review.subprocess, "run", fake_run)
+    return calls
+
+
+def _find_response(nodes):
+    body = {"data": {"repository": {"pullRequest": {"reviews": {"nodes": nodes}}}}}
+    return SimpleNamespace(returncode=0, stdout=json.dumps(body), stderr="")
+
+
+def test_appends_to_existing_pending_review(monkeypatch, capsys):
+    responses = [
+        _find_response([{"id": "REV1", "viewerDidAuthor": True}]),
+        SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"data": {"addPullRequestReviewThread": {"thread": {"id": "TH1"}}}}),
+            stderr="",
+        ),
+    ]
+    calls = _patch_run(monkeypatch, responses)
+    monkeypatch.setattr(sys, "argv", _argv())
+
+    append_review.main()
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["review_id"] == "REV1"
+    assert out["added"] == 1
+    assert out["thread_ids"] == ["TH1"]
+    assert len(calls) == 2  # find query + one mutation
+
+
+def test_errors_when_no_pending_review(monkeypatch, capsys):
+    responses = [_find_response([])]
+    calls = _patch_run(monkeypatch, responses)
+    monkeypatch.setattr(sys, "argv", _argv())
+
+    with pytest.raises(SystemExit) as exc:
+        append_review.main()
+
+    assert exc.value.code != 0
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"] == "no_pending_review"
+    assert len(calls) == 1  # only the find query, no mutation

--- a/tests/test_append_review.py
+++ b/tests/test_append_review.py
@@ -61,6 +61,19 @@ def test_appends_to_existing_pending_review(monkeypatch, capsys):
     assert len(calls) == 2  # find query + one mutation
 
 
+def test_thread_variables_omits_start_fields_when_absent():
+    comment_no_start = {"path": "a.py", "body": "x", "line": 5, "side": "RIGHT"}
+    result = append_review.thread_variables("REV1", comment_no_start)
+    assert set(result.keys()) == {"reviewId", "path", "body", "line", "side"}
+    assert "startLine" not in result
+    assert "startSide" not in result
+
+    comment_with_start = {"path": "a.py", "body": "x", "line": 5, "side": "RIGHT", "start_line": 2}
+    result_start = append_review.thread_variables("REV1", comment_with_start)
+    assert result_start["startLine"] == 2
+    assert result_start["startSide"] == "RIGHT"
+
+
 def test_errors_when_no_pending_review(monkeypatch, capsys):
     responses = [_find_response([])]
     calls = _patch_run(monkeypatch, responses)

--- a/tests/test_create_review.py
+++ b/tests/test_create_review.py
@@ -1,0 +1,71 @@
+"""Tests for create_review.py pending-review detection."""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from gh_ops import create_review
+
+_COMMENTS = json.dumps([{"path": "a.py", "line": 1, "body": "x"}])
+
+
+def _argv() -> list[str]:
+    return [
+        "create_review.py",
+        "--owner",
+        "o",
+        "--repo",
+        "r",
+        "--pull-number",
+        "1",
+        "--summary-body",
+        "s",
+        "--comments-json",
+        _COMMENTS,
+    ]
+
+
+def _patch_run(monkeypatch, responses):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return responses.pop(0)
+
+    monkeypatch.setattr(create_review.subprocess, "run", fake_run)
+    return calls
+
+
+def test_aborts_when_pending_review_exists(monkeypatch, capsys):
+    responses = [
+        SimpleNamespace(returncode=0, stdout=json.dumps([{"id": 5, "state": "PENDING"}]), stderr="")
+    ]
+    calls = _patch_run(monkeypatch, responses)
+    monkeypatch.setattr(sys, "argv", _argv())
+
+    with pytest.raises(SystemExit) as exc:
+        create_review.main()
+
+    assert exc.value.code != 0
+    err = json.loads(capsys.readouterr().err)
+    assert err["error"] == "pending_review_exists"
+    assert err["review_id"] == 5
+    assert len(calls) == 1  # only the list-reviews call, no POST
+
+
+def test_creates_when_no_pending_review(monkeypatch, capsys):
+    responses = [
+        SimpleNamespace(returncode=0, stdout="[]", stderr=""),
+        SimpleNamespace(
+            returncode=0, stdout=json.dumps({"id": 10, "html_url": "http://x"}), stderr=""
+        ),
+    ]
+    calls = _patch_run(monkeypatch, responses)
+    monkeypatch.setattr(sys, "argv", _argv())
+
+    create_review.main()
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["id"] == 10
+    assert len(calls) == 2  # list-reviews then POST


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/200

## Changes
- create_review.py が既存の pending review を検出し pending_review_exists で安全に中断
- append_review.py / append_review.sh を新設し GraphQL addPullRequestReviewThread で既存 pending review にコメントを追記
- pr-review-rules.md / SKILL.md に create と append の振り分けを明記
- 検出・追記経路の pytest 焦点テストを追加

## Confirmation Results
- uv run pytest: 245 passed
- mise run format / mise run lint: クリーン

## Review Points
- GraphQL addPullRequestReviewThread の利用
- pending review 検出は viewer 自身のみ対象

## Limitations
- 複数コメント追記はトランザクション非対応（途中失敗時のロールバックなし）
- pending review 検索クエリは first: 100（ページネーションなし）