### PR TITLE
feat: add kotlin treesitter parser and kotlin_lsp to neovim

### DIFF
--- a/.config/nvim/lua/plugins/mason.lua
+++ b/.config/nvim/lua/plugins/mason.lua
@@ -48,6 +48,7 @@ return {
 					"cspell-lsp", -- CSpell
 					"eslint_d", -- Javascript and Typescript linter
 					"gopls", -- Go lang LSP
+					"kotlin_lsp", -- Kotlin LSP (JetBrains kotlin-lsp)
 					"kulala-fmt", -- HTTP formatter and linter
 					"lua_ls", -- Lua LSP
 					"marksman", -- Markdown LSP

--- a/.config/nvim/lua/plugins/treesitter.lua
+++ b/.config/nvim/lua/plugins/treesitter.lua
@@ -36,6 +36,7 @@ local parsers = {
 	"jsdoc",
 	"json",
 	"jsonc",
+	"kotlin",
 	"lua",
 	"make",
 	"markdown",


### PR DESCRIPTION
- add "kotlin" parser to nvim-treesitter for syntax highlighting (covers Jetpack Compose)
- add "kotlin_lsp" (JetBrains kotlin-lsp) to mason ensure_installed; auto-enabled via mason-lspconfig
