### PR TITLE
chore: let node/python major-line updates be decided manually

### DIFF
--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -3,7 +3,7 @@ aws-vault = "7.2.0"
 awscli = { version = "2.35.11", symlink_bins = "true" }
 cargo-binstall = "1.20.1"
 "cargo:tree-sitter-cli" = "0.26.8"                        # for neovim
-claude = "2.1.195"
+claude = "2.1.205"
 delta = "0.19.2"
 fzf = "0.73.1"
 gemini-cli = "0.49.0"

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,20 @@
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "groupName": "github actions (patch)",
       "automerge": true
+    },
+    {
+      "description": "Node.js major-line updates are decided manually",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Python minor releases (e.g. 3.14 -> 3.15) are treated as major-line updates and decided manually",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["python"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Related URLs

## Changes
- disable renovate automerge for node major-line updates (decided manually)
- disable renovate automerge for python minor-line updates, treated as major-line (decided manually)
- bump claude to 2.1.205 in linux mise config

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->