### PR TITLE
fix: kulala-coreを事前取得し.httpフォーマットのタイムアウトを回避する

### DIFF
--- a/.config/nvim/lua/plugins/mason.lua
+++ b/.config/nvim/lua/plugins/mason.lua
@@ -76,6 +76,33 @@ return {
 					["mason-nvim-dap"] = false,
 				},
 			})
+
+			-- kulala-fmtが導入・更新された直後に、内部で利用するkulala-coreバイナリを
+			-- バックグラウンドで事前取得しておく。
+			-- conform.nvimの初回フォーマットはタイムアウトが短く、
+			-- kulala-core初回取得（63MBのダウンロード）が間に合わないため。
+			vim.api.nvim_create_autocmd("User", {
+				pattern = "MasonToolsUpdateCompleted",
+				callback = function(args)
+					-- kulala-fmtが今回インストール・更新された場合のみ事前取得する
+					if type(args.data) ~= "table" or not vim.tbl_contains(args.data, "kulala-fmt") then
+						return
+					end
+					local bin = vim.fn.stdpath("data") .. "/mason/bin/kulala-fmt"
+					if vim.fn.executable(bin) ~= 1 then
+						return
+					end
+					-- kulala-coreの初回ダウンロードを発生させるための使い捨てファイル
+					local tmp = vim.fn.tempname() .. ".http"
+					if vim.fn.writefile({ "GET https://example.com" }, tmp) ~= 0 then
+						return
+					end
+					-- conformのフォーマットタイムアウト外でバックグラウンド実行する（best-effort）
+					vim.system({ bin, "check", "--quiet", tmp }, {}, function()
+						os.remove(tmp)
+					end)
+				end,
+			})
 		end,
 	},
 }


### PR DESCRIPTION
## 変更点

- mason-tool-installer の `MasonToolsUpdateCompleted` イベントに autocmd を追加
- kulala-fmt が導入・更新された時のみ、使い捨ての `.http` ファイルに対して `kulala-fmt check` をバックグラウンド実行
- conform の 1000ms フォーマットタイムアウトの外で kulala-core(約63MB)を事前取得し、初回の `.http` フォーマットがタイムアウトしないようにする

## 確認結果

- `mise run format` / `mise run lint` がエラーなく通過(lint は 138 ファイル、エラー 0)
- `luac -p` で Lua 構文の正当性を確認

## レビュー観点

- `args.data` に `kulala-fmt` が含まれる場合のみ事前取得する判定ロジック
- `vim.system` によるバックグラウンド実行と一時ファイルの後始末(`os.remove`)

## 制限事項

- 既存の導入済み環境では次回の kulala-fmt 更新まで autocmd が発火しないため、即時解消には手動で一度 `kulala-fmt check` を実行しキャッシュを温める必要がある
- 対象は conform 経由(kulala-fmt)の kulala-core キャッシュのみ。`:Kulala` 実行が使う kulala.nvim 内蔵の別キャッシュは対象外(YAGNI)

## 補足(根本原因)

`@mistweaverco/kulala-fmt` は初回実行時に kulala-core(約63MB)を遅延ダウンロードする。これが conform の 1000ms タイムアウトを超えるため、キャッシュが温まらず `.http` フォーマットが必ずタイムアウトしていた。
