### PR TITLE
chore: remove gh-ops pre-write confirmation and switch to RunCatNeo

### DIFF
--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -14,7 +14,8 @@ description: >
 - Execute all scripts using absolute paths: `bash "${SKILL_DIR}/scripts/<name>"`
 - Use only shipped scripts; do not run extra git or gh commands
 - Do NOT read the script; use it as a black box.
-- Always confirm content with the user before any write operation
+- Write only when the user has explicitly requested the operation; do not ask
+  for pre-write content approval
 - Default language is English unless user explicitly requests otherwise
 - On script validation error or API failure: show raw error, stop
 

--- a/.config/claude/skills/gh-ops/references/issue-comment-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-comment-rules.md
@@ -29,11 +29,7 @@ Provide content as stdin JSON:
 
 If `details` is omitted or empty, a summary-only comment is posted.
 
-### Step 2: Confirm with User
-
-Present the composed summary and details. Proceed only after explicit approval.
-
-### Step 3: Post Comment
+### Step 2: Post Comment
 
 Required flags:
 

--- a/.config/claude/skills/gh-ops/references/issue-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/issue-create-rules.md
@@ -47,11 +47,7 @@ feature:
 }
 ```
 
-### Step 3: Confirm with User
-
-Present the composed issue content. Proceed only after explicit approval.
-
-### Step 4: Create Issue
+### Step 3: Create Issue
 
 Optional flags:
 

--- a/.config/claude/skills/gh-ops/references/pr-create-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-create-rules.md
@@ -54,12 +54,7 @@ Optional flags:
 - `--additional` – Any extra context
 - `--base` – Base branch (default: repo default branch)
 
-### Step 5: Confirm with User
-
-Present the composed title, type, and body content. Proceed only after explicit
-approval.
-
-### Step 6: Create Draft PR
+### Step 5: Create Draft PR
 
 ```bash
 bash "${SKILL_DIR}/scripts/create-pr.sh" \

--- a/.config/claude/skills/gh-ops/references/pr-review-rules.md
+++ b/.config/claude/skills/gh-ops/references/pr-review-rules.md
@@ -35,11 +35,7 @@ Optional per comment:
 
 Provide `--comments-json` as a valid JSON array with at least one element.
 
-### Step 2: Confirm with User
-
-Present the composed comments and summary. Proceed only after explicit approval.
-
-### Step 3: Create Review
+### Step 2: Create Review
 
 Required flags:
 
@@ -81,10 +77,10 @@ On success, stdout contains
 has no `--summary-body` flag. If no pending review exists it reports
 `{"error": "no_pending_review"}`; use `create_review.sh` in that case.
 
-### Step 4: Do Not Submit the Review
+### Step 3: Do Not Submit the Review
 
-The review is created as a pending draft. Do not submit it via the CLI.
-The user will submit it manually via the GitHub UI when ready.
+The review is created as a pending draft. Do not submit it via the CLI. The
+user will submit it manually via the GitHub UI when ready.
 
 ## Output
 

--- a/.config/homebrew/Brewfile
+++ b/.config/homebrew/Brewfile
@@ -3,7 +3,7 @@
 # === application management
 brew "mas"
 # cask "appcleaner"
-mas "RunCat", id: 1429033973
+mas "RunCatNeo", id: 6757801838
 
 # === communication tools
 # cask "brave-browser"


### PR DESCRIPTION
## Related URLs

## Changes
- gh-ops: 全操作から事前の「Confirm with User」ステップを削除
- gh-ops: SKILL.md の制約を「明示的指示があるときのみ書き込む/事前承認は求めない」に変更
- Homebrew Brewfile: RunCat を RunCatNeo に変更

## Confirmation Results
- mise run format / mise run lint がパス

## Review Points
- 独立した2変更(gh-ops のフロー変更と RunCatNeo への切替)を含む macbook-air-m4 の蓄積分

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->