### PR TITLE
refactor: consolidate setup script duplication into shared library

### DIFF
--- a/.config/mise/config-colima.toml
+++ b/.config/mise/config-colima.toml
@@ -18,7 +18,6 @@ neovim = "0.12.3"
 node = "24.18.0"
 "npm:@aikidosec/safe-chain" = "1.5.10"
 "npm:@anthropic-ai/sandbox-runtime" = "0.0.61"          # for claude code
-"npm:@github/copilot" = "1.0.63"
 "npm:@github/copilot" = "1.0.65"
 "npm:ccstatusline" = "2.2.22"                           # for claude code
 "npm:ccusage" = "20.0.14"                               # for claude code

--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -45,11 +45,6 @@ This is the highest-priority rule.
 - Code is readable and maintainable.
 - User requirements are met exactly — no more, no less.
 
-### Task Completion Protocol
-
-Call the `question` tool at the end of every response.
-A task is complete only when the user explicitly confirms it.
-
 ## Style and Preferences
 
 - Do not use emojis in code, comments, or documentation.

--- a/.config/opencode/opencode.jsonc
+++ b/.config/opencode/opencode.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
   // Models
-  "model": "deepseek/deepseek-v4-pro",
+  "model": "openrouter/moonshotai/kimi-k3",
   "small_model": "opencode/big-pickle", // タイトル生成などに利用
   "agent": {
     // ここに組み込みの subagent の model を指定することでデフォルトのモデルを指定できる
@@ -11,71 +11,54 @@
     // 2. この部分で指定した設定
     // 3. 親エージェントのモデル継承
     "build": {
-      // ユーザーインターフェースなので Opus 4.6 Tier が欲しい
-      "model": "openrouter/moonshotai/kimi-k2.6"
+      // ユーザーインターフェースなので OpusTier が欲しい
+      "model": "openrouter/moonshotai/kimi-k3"
     },
     "explore": {
       // 探索 subagent なので Haiku Tier で良い
-      "model": "openrouter/minimax/minimax-m2.7"
+      "model": "openrouter/deepseek/deepseek-v4-pro"
     },
     "general": {
       // 作業用 subagent なので Sonnet Tier で良い
-      "model": "openrouter/deepseek/deepseek-v4-pro"
+      "model": "z-ai/glm-5.2"
     },
     "plan": {
-      // ユーザーインターフェースかつ Planning なので本当は Opus 4.7 Tier が欲しい
-      "model": "openrouter/moonshotai/kimi-k2.6"
+      // ユーザーインターフェースかつ Planning なので本当は Opus Tier が欲しい
+      "model": "openrouter/moonshotai/kimi-k3"
     }
   },
   "provider": {
-    "github-copilot": {
-      "whitelist": [
-        "claude-sonnet-4.6",
-        "claude-haiku-4.5",
-        "gemini-3.1-pro-preview",
-        "gpt-5.4"
-      ]
-    },
     "openrouter": {
       "whitelist": [
-        // === Tier: Opus 4.7 AAII Score
-        // Claude Opus 4.7: Context: 1M, AAII 57
-        // Input: $5, Output: $25
-        "anthropic/claude-opus-4.7",
-        // GPT-5.5: Context: 1M, AAII: 60
-        // <=272K: Input: $5, Output: $30
-        // >272K: Input: $10, Output: $45
-        "openai/gpt-5.5",
-        // GPT-5.4: Context: 1M, AAII: 57
-        // <=272K: Input: $2.5, Output: $15
-        // >272K: Input: $5, Output: $22.50
-        "openai/gpt-5.4",
-        // === Tier: Opus 4.6 AAII Score
-        // Claude Opus 4.6: Context: 1M, AAII: 53
-        // Input: $5, Output: $25
-        "anthropic/claude-opus-4.6",
-        // MiMo-V2.5-Pro: AAII: 54
-        // <=256K: Input: $1, Output: $3
-        // >256K: Input: $2, Output: $6
-        "xiaomi/mimo-v2.5-pro",
-        // Kimi K2.6: Context: 256 K, AAII: 54
-        // Input: $0.8, Output: $3.5
-        "moonshotai/kimi-k2.6",
-        // === Tier: Sonnet 4.6 AAII Score
-        // Claude Sonnet 4.6: Context: 1M, AAII: 52
+        // === Tier: Fable
+        // Claude Fable5: Context: 1M, AAII 60
+        // Input: $10, Output: $50
+        "anthropic/claude-fable-5",
+        // GPT-5.6 Sol: Context: 1M, AAII: 59
+        // Input: $5, Output: $30
+        "openai/gpt-5.6-sol",
+        // === Tier: Opus
+        // Kimi K3: Context: 1M, AAII: 57
         // Input: $3, Output: $15
-        "anthropic/claude-sonnet-4.6",
-        // DeepSeek V4 Pro: Context: 1M, AAII: 52
+        "moonshotai/kimi-k3",
+        // Claude Opus 4.8: Context: 1M, AAII 56
+        // Input: $5, Output: $25
+        "anthropic/claude-opus-4.8",
+        // GPT-5.6 Terra: Context: 1M, AAII: 55
+        // Input: $2.5, Output: $15
+        "openai/gpt-5.6-terra",
+        // === Tier: Sonnet AAII Score
+        // Claude Sonnet 5: Context: 1M, AAII: 53
+        // Input: $2, Output: $10
+        "anthropic/claude-sonnet-5",
+        // GLM 5.2: Context 1M, AAII: 52
+        // Input: $1.4, Output: $4.4
+        "z-ai/glm-5.2",
+        // === Tier: Haiku AAII Score
+        // DeepSeek V4 Pro: Context: 1M, AAII: 44
         // Input: $0.43, Output: $0.87
         "deepseek/deepseek-v4-pro",
-        // MiniMax M2.7: Context: 200K, AAII: 50
-        // Input: $0.3, Output: $1.2
-        "minimax/minimax-m2.7",
-        // GLM 5.1: Context 200K, AAII: 51
-        // Input: $1.05, Output: $3.5
-        "z-ai/glm-5.1",
-        // === Tier: Haiku 4.5 AAII Score
-        // Claude Haiku 4.5: Context: 200K, AAII: 37
+        // Claude Haiku 4.5: Context: 200K, AAII: 30
         // Input: $1, Output: $5
         "anthropic/claude-haiku-4.5"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,15 @@ jobs:
 
       - name: Run Lint
         run: mise run lint
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      MISE_IGNORED_CONFIG_PATHS: ${{ github.workspace }}/.config/mise/config-mac.toml:${{ github.workspace }}/.config/mise/config-linux.toml
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+
+      - name: Run Test
+        run: mise run test

--- a/.mise/tasks/test.sh
+++ b/.mise/tasks/test.sh
@@ -2,3 +2,4 @@
 set -euo pipefail
 
 uv run pytest "$@"
+bats tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ mise run setup # install all tools
 
 - Lint: `mise run lint`
 - Format: `mise run format`
-- Test: `mise run test`
+- Test: `mise run test` (runs pytest, then bats)
 
 Run `mise run format` and `mise run lint` after any modifications.
 
@@ -33,7 +33,9 @@ Run `mise run format` and `mise run lint` after any modifications.
 - `.claude/`: Claude Code runtime directory (settings.json, agents, commands/)
 - `.mise/`: Mise task definitions (shell scripts invoked by `mise run`)
 - `docs/`: Design documents and ADRs
-- `tests/`: Python test suite (primarily tests for hook scripts)
+- `lib/`: Shared shell libraries sourced by setup scripts (e.g. `setup-common.sh`)
+- `tests/`: Test suites — pytest (hook scripts, repository integrity) and bats
+  (shell helper functions in `lib/`); both run via `mise run test`
 - `lefthook.yml`: Pre-commit hook definition (runs format → lint + test automatically)
 - `setup_*.sh` / `update_*.sh`: Platform-specific environment setup scripts at root
 
@@ -43,6 +45,7 @@ Platform-specific setup scripts follow the `setup_*.sh` pattern; update scripts 
 
 ## CI
 
-The CI workflow (`.github/workflows/ci.yml`) only runs `mise run lint`.
+The CI workflow (`.github/workflows/ci.yml`) runs `mise run lint` and `mise run test`
+as parallel jobs.
 Platform-specific mise configs are loaded only via symlinks created by `setup_*.sh` scripts,
 so they are not present in the CI environment.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,5 +11,5 @@ pre-commit:
             glob: "**/*.{sh,md,py}"
             run: mise run lint -- {staged_files}
           - name: test
-            glob: "**/*.py"
+            glob: "**/*.{py,bats,sh}"
             run: mise run test

--- a/lib/setup-common.sh
+++ b/lib/setup-common.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Shared helper functions sourced by setup scripts.
+
+# Create symlink if link does not exist.
+function create_symlink() {
+  local -r src=$1
+  local -r dst=$2
+
+  if [ -e "$dst" ]; then
+    echo "already exist $dst"
+    return 0
+  fi
+
+  echo "symlink $src to $dst"
+  mkdir -p "$(dirname "$dst")"
+  ln -s "$src" "$dst"
+}
+
+# Create hardlink if link does not exist.
+function create_hardlink() {
+  local -r src=$1
+  local -r dst=$2
+
+  if [ -e "$dst" ]; then
+    echo "already exist $dst"
+    return 0
+  fi
+
+  echo "symlink $src to $dst"
+  mkdir -p "$(dirname "$dst")"
+  ln "$src" "$dst"
+}
+
+# Add loading file in .bashrc or .zshrc.
+function set_bashrc() {
+  local -r filename="$1"
+
+  if [[ "$SHELL" == *zsh* ]]; then
+    # zshを利用しているので設定ファイルが異なる
+    local -r rcfile="$HOME/.zshrc"
+  else
+    # bashを想定している
+    local -r rcfile="$HOME/.bashrc"
+  fi
+
+  # if setting exits in rc file, do nothing.
+  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
+    echo "already setting in $rcfile: $filename"
+    return 0
+  fi
+
+  # Add file path.
+  echo "set load setting in $rcfile: $filename"
+  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
+}
+
+# Add Claude Code user-scope MCP server if not already configured.
+#
+# Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
+# Usage: add_claude_mcp <name> <cmd> [args...]
+function add_claude_mcp() {
+  local -r name=$1
+  shift
+
+  local output
+  output=$(claude mcp get "$name" 2>&1 || true)
+  if ! echo "$output" | grep -qF "No MCP server found"; then
+    echo "already exist claude mcp: $name"
+    return 0
+  fi
+
+  echo "add claude mcp: $name"
+  claude mcp add --transport stdio --scope user "$name" -- "$@"
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 "aqua:LuaLS/lua-language-server" = "3.18.2"
+bats = "latest"
 "npm:bash-language-server" = "5.6.0"
 shfmt = "3.13.1"
 shellcheck = "0.11.0"

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -4,78 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
-# Create hardlink if link does not exist.
-function create_hardlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln "$src" "$dst"
-}
-
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
-# Add Claude Code user-scope MCP server if not already configured.
-#
-# Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
-# Usage: add_claude_mcp <name> <cmd> [args...]
-function add_claude_mcp() {
-  local -r name=$1
-  shift
-
-  local output
-  output=$(claude mcp get "$name" 2>&1 || true)
-  if ! echo "$output" | grep -qF "No MCP server found"; then
-    echo "already exist claude mcp: $name"
-    return 0
-  fi
-
-  echo "add claude mcp: $name"
-  claude mcp add --transport stdio --scope user "$name" -- "$@"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -84,6 +12,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # Installが確認できていないツール
 # - eza

--- a/setup_codespaces.sh
+++ b/setup_codespaces.sh
@@ -4,44 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -50,6 +12,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # 各種設定ファイルの配置もしくは読み込み設定
 set_bashrc "$CONFIG_PATH/rc-settings.sh"

--- a/setup_colima.sh
+++ b/setup_colima.sh
@@ -4,78 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create hardlink if link does not exist.
-function create_hardlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln "$src" "$dst"
-}
-
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
-# Add Claude Code user-scope MCP server if not already configured.
-#
-# Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
-# Usage: add_claude_mcp <name> <cmd> [args...]
-function add_claude_mcp() {
-  local -r name=$1
-  shift
-
-  local output
-  output=$(claude mcp get "$name" 2>&1 || true)
-  if ! echo "$output" | grep -qF "No MCP server found"; then
-    echo "already exist claude mcp: $name"
-    return 0
-  fi
-
-  echo "add claude mcp: $name"
-  claude mcp add --transport stdio --scope user "$name" -- "$@"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -84,6 +12,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # Installが確認できていないツール
 # - eza

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -4,78 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create hardlink if link does not exist.
-function create_hardlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln "$src" "$dst"
-}
-
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
-# Add Claude Code user-scope MCP server if not already configured.
-#
-# Claude Code のユーザーレベル MCP 設定は他の情報がありリポジトリで管理できないので設定で対応する
-# Usage: add_claude_mcp <name> <cmd> [args...]
-function add_claude_mcp() {
-  local -r name=$1
-  shift
-
-  local output
-  output=$(claude mcp get "$name" 2>&1 || true)
-  if ! echo "$output" | grep -qF "No MCP server found"; then
-    echo "already exist claude mcp: $name"
-    return 0
-  fi
-
-  echo "add claude mcp: $name"
-  claude mcp add --transport stdio --scope user "$name" -- "$@"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -84,6 +12,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # === Install [homebrew](https://brew.sh/index_ja)
 # if ! type brew >/dev/null 2>&1; then

--- a/setup_proot_arm64.sh
+++ b/setup_proot_arm64.sh
@@ -4,21 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
 # install cica
 # See: <https://github.com/miiton/Cica>
 function _install_cica() {
@@ -48,29 +33,6 @@ function _install_yq() {
   sudo install yq -D -t /usr/local/bin/
 }
 
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -79,6 +41,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # Installが確認できていないツール
 # - eza

--- a/setup_termux.sh
+++ b/setup_termux.sh
@@ -4,44 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -50,6 +12,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # Installが確認できていないツール
 # - eza

--- a/setup_wsl_ubuntu.sh
+++ b/setup_wsl_ubuntu.sh
@@ -4,21 +4,6 @@
 set -eu
 set -o pipefail
 
-# Create symlink if link does not exist.
-function create_symlink() {
-  local -r src=$1
-  local -r dst=$2
-
-  if [ -e "$dst" ]; then
-    echo "already exist $dst"
-    return 0
-  fi
-
-  echo "symlink $src to $dst"
-  mkdir -p "$(dirname "$dst")"
-  ln -s "$src" "$dst"
-}
-
 # Install lazygit
 # see: <https://github.com/jesseduffield/lazygit?tab=readme-ov-file#installation>
 # ubuntu25.10以降は単純にaptでインストール可能になる。
@@ -50,29 +35,6 @@ function _install_yq() {
   sudo install yq -D -t /usr/local/bin/
 }
 
-# Add loading file in .bashrc or .zshrc.
-function set_bashrc() {
-  local -r filename="$1"
-
-  if [[ "$SHELL" == *zsh* ]]; then
-    # zshを利用しているので設定ファイルが異なる
-    local -r rcfile="$HOME/.zshrc"
-  else
-    # bashを想定している
-    local -r rcfile="$HOME/.bashrc"
-  fi
-
-  # if setting exits in rc file, do nothing.
-  if grep -qF -- "$filename" "$rcfile" >/dev/null 2>&1; then
-    echo "already setting in $rcfile: $filename"
-    return 0
-  fi
-
-  # Add file path.
-  echo "set load setting in $rcfile: $filename"
-  echo -e "if [ -f \"${filename}\" ]; then . \"${filename}\"; fi\n" >>"$rcfile"
-}
-
 # === 共通パスの設定
 SCRIPT_DIR=
 SCRIPT_DIR=$(
@@ -81,6 +43,9 @@ SCRIPT_DIR=$(
 )
 readonly SCRIPT_DIR
 readonly CONFIG_PATH=$SCRIPT_DIR/.config
+
+# Load shared helper functions
+. "$SCRIPT_DIR/lib/setup-common.sh"
 
 # Installが確認できていないツール
 # - eza

--- a/tests/setup_common.bats
+++ b/tests/setup_common.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+
+# Tests for lib/setup-common.sh shared helper functions.
+
+setup() {
+  source "$BATS_TEST_DIRNAME/../lib/setup-common.sh"
+}
+
+# --- create_symlink ---
+
+@test "create_symlink: creates a symlink from src to dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/dst_link"
+  echo "content" >"$src"
+
+  run create_symlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"symlink"* ]]
+  [ -L "$dst" ]
+  [ "$(readlink "$dst")" = "$src" ]
+}
+
+@test "create_symlink: auto-creates missing parent directories of dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/a/b/c/dst_link"
+  echo "content" >"$src"
+
+  run create_symlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [ -L "$dst" ]
+  [ "$(readlink "$dst")" = "$src" ]
+}
+
+@test "create_symlink: returns 0 and does not modify existing dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/existing_dst"
+  echo "content" >"$src"
+  echo "existing" >"$dst"
+
+  run create_symlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exist"* ]]
+  # dst is still a regular file, not a symlink
+  [ ! -L "$dst" ]
+  [ "$(cat "$dst")" = "existing" ]
+}
+
+# --- create_hardlink ---
+
+@test "create_hardlink: creates a hard link from src to dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/dst_link"
+  echo "content" >"$src"
+
+  run create_hardlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [ -e "$dst" ]
+  [ ! -L "$dst" ]
+  # Hard link shares inode
+  local src_inode dst_inode
+  src_inode=$(stat -c %i "$src")
+  dst_inode=$(stat -c %i "$dst")
+  [ "$src_inode" = "$dst_inode" ]
+}
+
+@test "create_hardlink: auto-creates missing parent directories of dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/a/b/c/dst_link"
+  echo "content" >"$src"
+
+  run create_hardlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [ -e "$dst" ]
+  local src_inode dst_inode
+  src_inode=$(stat -c %i "$src")
+  dst_inode=$(stat -c %i "$dst")
+  [ "$src_inode" = "$dst_inode" ]
+}
+
+@test "create_hardlink: returns 0 and does not modify existing dst" {
+  local src="$BATS_TEST_TMPDIR/src_file"
+  local dst="$BATS_TEST_TMPDIR/existing_dst"
+  echo "content" >"$src"
+  echo "existing" >"$dst"
+  local original_inode
+  original_inode=$(stat -c %i "$dst")
+
+  run create_hardlink "$src" "$dst"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exist"* ]]
+  # dst unchanged: same inode, same content
+  local dst_inode
+  dst_inode=$(stat -c %i "$dst")
+  [ "$dst_inode" = "$original_inode" ]
+  [ "$(cat "$dst")" = "existing" ]
+}
+
+# --- set_bashrc ---
+
+@test "set_bashrc: appends source line to .bashrc when SHELL=/bin/bash" {
+  local home_dir="$BATS_TEST_TMPDIR/fakehome"
+  mkdir -p "$home_dir"
+  HOME="$home_dir"
+  SHELL=/bin/bash
+
+  run set_bashrc "/some/file.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set load setting"* ]]
+  grep -qF "/some/file.sh" "$home_dir/.bashrc"
+}
+
+@test "set_bashrc: appends source line to .zshrc when SHELL=/bin/zsh" {
+  local home_dir="$BATS_TEST_TMPDIR/fakehome"
+  mkdir -p "$home_dir"
+  HOME="$home_dir"
+  SHELL=/bin/zsh
+
+  run set_bashrc "/some/file.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set load setting"* ]]
+  grep -qF "/some/file.sh" "$home_dir/.zshrc"
+  # .bashrc should NOT exist
+  [ ! -f "$home_dir/.bashrc" ]
+}
+
+@test "set_bashrc: calling twice does not duplicate the entry" {
+  local home_dir="$BATS_TEST_TMPDIR/fakehome"
+  mkdir -p "$home_dir"
+  HOME="$home_dir"
+  SHELL=/bin/bash
+
+  run set_bashrc "/some/file.sh"
+  [ "$status" -eq 0 ]
+
+  run set_bashrc "/some/file.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already setting"* ]]
+
+  # Count occurrences: should be exactly 1
+  local count
+  count=$(grep -cF "/some/file.sh" "$home_dir/.bashrc")
+  [ "$count" -eq 1 ]
+}
+
+# --- add_claude_mcp ---
+
+@test "add_claude_mcp: calls claude mcp add when MCP server not found" {
+  # Create a stub claude that records args and returns "No MCP server found"
+  local bin_dir="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$bin_dir"
+  local args_log="$BATS_TEST_TMPDIR/claude_args.log"
+
+  cat >"$bin_dir/claude" <<STUB
+#!/bin/bash
+echo "\$@" >> "$args_log"
+if [ "\$1" = "mcp" ] && [ "\$2" = "get" ]; then
+  echo "No MCP server found"
+fi
+STUB
+  chmod +x "$bin_dir/claude"
+  PATH="$bin_dir:$PATH"
+
+  run add_claude_mcp "my-server" "npx" "-y" "some-mcp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"add claude mcp: my-server"* ]]
+
+  # Verify claude mcp add was called with correct args
+  grep -qF "mcp add --transport stdio --scope user my-server -- npx -y some-mcp" "$args_log"
+}
+
+@test "add_claude_mcp: skips when MCP server already exists" {
+  # Create a stub claude that returns something other than "No MCP server found"
+  local bin_dir="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$bin_dir"
+  local args_log="$BATS_TEST_TMPDIR/claude_args.log"
+
+  cat >"$bin_dir/claude" <<STUB
+#!/bin/bash
+echo "\$@" >> "$args_log"
+if [ "\$1" = "mcp" ] && [ "\$2" = "get" ]; then
+  echo "my-server: connected"
+fi
+STUB
+  chmod +x "$bin_dir/claude"
+  PATH="$bin_dir:$PATH"
+
+  run add_claude_mcp "my-server" "npx" "-y" "some-mcp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exist claude mcp: my-server"* ]]
+
+  # Verify claude mcp add was NOT called (only mcp get should appear)
+  if [ -f "$args_log" ]; then
+    ! grep -qF "mcp add" "$args_log"
+  fi
+}

--- a/tests/test_repo_integrity.py
+++ b/tests/test_repo_integrity.py
@@ -1,0 +1,168 @@
+"""Repository integrity tests.
+
+Ensures that path references in setup/update scripts point to files that
+actually exist, and that committed TOML / JSON files are parseable.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_ls_files(*patterns: str) -> list[str]:
+    """Return tracked files matching the given git pathspec patterns."""
+    result = subprocess.run(
+        ["git", "ls-files", *patterns],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+_SCRIPT_RE = re.compile(r"""\$SCRIPT_DIR/([a-zA-Z0-9_./-]+)""")
+_CONFIG_RE = re.compile(r"""\$CONFIG_PATH/([a-zA-Z0-9_./-]+)""")
+
+
+def _extract_path_references(script_path: Path) -> list[tuple[str, str]]:
+    """Extract ``$SCRIPT_DIR/...`` and ``$CONFIG_PATH/...`` references.
+
+    Returns a list of ``(variable, relative_path)`` tuples where *variable*
+    is ``SCRIPT_DIR`` or ``CONFIG_PATH`` and *relative_path* is the path
+    portion after the slash.
+
+    Lines that are shell comments (leading ``#`` after whitespace) are
+    skipped.  References whose captured path contains a ``$`` character are
+    also skipped (they reference other shell variables and cannot be resolved
+    statically).
+    """
+    references: list[tuple[str, str]] = []
+    for line in script_path.read_text().splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for match in _SCRIPT_RE.finditer(line):
+            path = match.group(1)
+            if "$" in path:
+                continue
+            references.append(("SCRIPT_DIR", path))
+        for match in _CONFIG_RE.finditer(line):
+            path = match.group(1)
+            if "$" in path:
+                continue
+            references.append(("CONFIG_PATH", path))
+    return references
+
+
+def _resolve_ref(variable: str, relative_path: str) -> Path:
+    """Resolve a ``$SCRIPT_DIR`` or ``$CONFIG_PATH`` reference to an absolute path."""
+    if variable == "SCRIPT_DIR":
+        return _REPO_ROOT / relative_path
+    # CONFIG_PATH is always $SCRIPT_DIR/.config
+    return _REPO_ROOT / ".config" / relative_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Setup script path references
+# ---------------------------------------------------------------------------
+
+
+def _collect_script_refs() -> list[tuple[str, str, str]]:
+    """Collect all path references across setup/update scripts.
+
+    Returns tuples of ``(script_name, variable, relative_path)``.
+    """
+    scripts = _git_ls_files("setup_*.sh", "update_*.sh")
+    refs: list[tuple[str, str, str]] = []
+    for script in scripts:
+        for variable, rel_path in _extract_path_references(_REPO_ROOT / script):
+            refs.append((script, variable, rel_path))
+    return refs
+
+
+_SCRIPT_REFS = _collect_script_refs()
+
+
+@pytest.mark.parametrize(
+    "script, variable, relative_path",
+    _SCRIPT_REFS,
+    ids=[f"{s}::{v}/{p}" for s, v, p in _SCRIPT_REFS],
+)
+def test_setup_script_references_exist(script: str, variable: str, relative_path: str) -> None:
+    """Every ``$SCRIPT_DIR/...`` and ``$CONFIG_PATH/...`` reference resolves to an existing path."""
+    resolved = _resolve_ref(variable, relative_path)
+    assert resolved.exists(), (
+        f"{script} references {variable}/{relative_path} "
+        f"which resolves to {resolved} but it does not exist"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. TOML files parse
+# ---------------------------------------------------------------------------
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore[assignment]
+
+_TOML_FILES = _git_ls_files("*.toml")
+
+
+@pytest.mark.skipif(tomllib is None, reason="No TOML parser available (need tomllib or tomli)")
+@pytest.mark.parametrize(
+    "toml_file",
+    _TOML_FILES,
+    ids=[str(Path(p).name) for p in _TOML_FILES],
+)
+def test_toml_files_parse(toml_file: str) -> None:
+    """Every tracked ``*.toml`` file is valid TOML."""
+    path = _REPO_ROOT / toml_file
+    with path.open("rb") as f:
+        tomllib.load(f)
+
+
+# ---------------------------------------------------------------------------
+# 3. JSON files parse
+# ---------------------------------------------------------------------------
+
+# devcontainer.json allows comments by specification (JSONC), so it is
+# excluded from strict JSON validation.
+_JSON_EXCLUDES = {".devcontainer/devcontainer.json"}
+_JSON_FILES = [f for f in _git_ls_files("*.json") if f not in _JSON_EXCLUDES]
+
+
+@pytest.mark.parametrize(
+    "json_file",
+    _JSON_FILES,
+    ids=[str(Path(p).name) for p in _JSON_FILES],
+)
+def test_json_files_parse(json_file: str) -> None:
+    """Every tracked ``*.json`` file is valid JSON."""
+    path = _REPO_ROOT / json_file
+    raw = path.read_bytes()
+    # Try common encodings: UTF-8 is standard; UTF-8-sig handles BOM;
+    # UTF-16-LE covers files exported by Windows tools (e.g. scoop).
+    for encoding in ("utf-8", "utf-8-sig", "utf-16"):
+        try:
+            text = raw.decode(encoding)
+            break
+        except (UnicodeDecodeError, ValueError):
+            continue
+    else:
+        msg = f"{json_file}: none of UTF-8/UTF-8-sig/UTF-16 could decode the file"
+        raise AssertionError(msg)
+    json.loads(text)


### PR DESCRIPTION
## Related URLs

## Changes
- extract common setup logic into lib/setup-common.sh and source it from all setup_*.sh scripts
- remove duplicate copilot entry from config-colima.toml
- add pytest tests for repository integrity
- add bats tests for setup-common.sh helper functions
- run pytest and bats via mise run test, and wire it into CI
- document test structure and shared libraries in AGENTS.md

## Confirmation Results

<!-- Describe preconditions, steps, and results of confirmation if any -->

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->