### PR TITLE
refactor: pre-commit の format を並列化し format→lint の順序を維持

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,22 +1,27 @@
 pre-commit:
   jobs:
-    - name: format-sh
-      glob: "**/*.sh"
-      stage_fixed: true
-      run: mise run format:sh -- {staged_files}
-    - name: format-toml
-      glob: "**/*.toml"
-      stage_fixed: true
-      run: mise run format:toml -- {staged_files}
-    - name: format-md
-      glob: "**/*.md"
-      stage_fixed: true
-      run: mise run format:md -- {staged_files}
-    - name: format-py
-      glob: "**/*.py"
-      stage_fixed: true
-      run: mise run format:py -- {staged_files}
-    - group:
+    - name: format
+      group:
+        parallel: true
+        jobs:
+          - name: format-sh
+            glob: "**/*.sh"
+            stage_fixed: true
+            run: mise run format:sh -- {staged_files}
+          - name: format-toml
+            glob: "**/*.toml"
+            stage_fixed: true
+            run: mise run format:toml -- {staged_files}
+          - name: format-md
+            glob: "**/*.md"
+            stage_fixed: true
+            run: mise run format:md -- {staged_files}
+          - name: format-py
+            glob: "**/*.py"
+            stage_fixed: true
+            run: mise run format:py -- {staged_files}
+    - name: lint
+      group:
         parallel: true
         jobs:
           - name: lint-sh


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/284

## Changes
- format ジョブを group (parallel: true) 化し、グループ内を並列実行
- format グループ → lint グループの逐次順序を維持
- lint グループ内の test は据え置き(format 完了後に read-only で実行)

## Confirmation Results
- mise exec -- lefthook dump で format グループ(parallel, 4 job)→ lint グループ(parallel, 4 job)の構造を確認
- コミット時に pre-commit hook がエラーなく完了することを確認

## Review Points
- issue #284 の文言「format/lint を並列で実行」からは意図的に逸脱し、format→lint の逐次順序を維持している点

## Limitations
- stage_fixed によるファイル書き込みと lint/test の読み込みが同一ファイルで競合するのを避けるため format→lint の順序を維持
- format と lint は互いに並列にはならず、高速化効果は format グループ内の並列化に限定される