### PR TITLE
refactor: mise の setup/test タスクを mise.toml のインライン定義へ移行

### DIFF
--- a/.config/copilot/skills/standards-mise/SKILL.md
+++ b/.config/copilot/skills/standards-mise/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: standards-mise
 description: >-
-  Use when creating or modifying mise tasks (file-based scripts in
-  .mise/tasks/ or inline tasks in mise.toml) to enforce naming conventions
-  and pick the right task pattern.
+  Use when creating or modifying mise tasks (inline tasks in mise.toml or
+  script-backed tasks in scripts/) to enforce naming conventions and pick
+  the right task pattern.
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -30,20 +30,22 @@ documentation, these rules take precedence.
 Two ways to define a task exist in this repo; pick based on what the task
 needs.
 
-- **File-based** (`.mise/tasks/`): use when the task needs real shell
-  positional args (`$@`), bash-only features, or non-trivial logic.
-  Examples: `setup`, `test`.
-- **Inline** (`mise.toml` `[tasks]`): use for simple, single-purpose tasks.
-  Examples: the per-tool `format:*` / `lint:*` tasks and the `format` /
-  `lint` umbrella tasks that `depends` on them.
+- **Inline** (`mise.toml` `[tasks]`): the default. Use for simple,
+  single-purpose tasks. Examples: `setup`, the per-tool `format:*` /
+  `lint:*` / `test:*` tasks, and the `format` / `lint` / `test` umbrella
+  tasks that `depends` on them.
+- **Script-backed** (`scripts/`): use when the task needs bash-only
+  features or non-trivial logic. Place the script in `scripts/` and
+  reference it from an inline task's `run`. No current task needs this.
 
 ### Naming Convention
 
-- File-based tasks: always include a file extension (`.sh` for shell
-  scripts). mise uses the filename without extension as the task name.
-  Example: `setup.sh` becomes task `setup`.
 - Inline tasks: the `[tasks]` table key is the task name, e.g.
   `[tasks."format:sh"]` becomes task `format:sh`.
+- Sub-tasks use a target-language suffix (`format:py` / `lint:sh` /
+  `test:py`); umbrella tasks aggregate them via `depends`.
+- Script-backed tasks: name the script after the task with a file
+  extension, e.g. `scripts/setup.sh` referenced by `[tasks.setup]`.
 
 ### Inline Task Arguments
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 
 - Setup Scripts: `setup_*.sh`, `update_*.sh`
 - Configurations: `.config/`
-- Mise Settings: `.mise/`
+- Mise Settings: `mise.toml`
 - Documents: `docs/`
   - Design: `docs/design/`
   - Planning: `docs/planning.md`

--- a/.mise/tasks/setup.sh
+++ b/.mise/tasks/setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# git worktree においては、ルートリポジトリ側で lefthook が設定されていればいいのでスキップ
-if [ -d ".git" ]; then
-  lefthook install
-fi

--- a/.mise/tasks/test.sh
+++ b/.mise/tasks/test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-uv run pytest "$@"
-bats tests/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ mise run setup # install all tools
 
 - Lint: `mise run lint`
 - Format: `mise run format`
-- Test: `mise run test` (runs pytest, then bats)
+- Test: `mise run test` (runs pytest and bats)
 
 Run `mise run format` and `mise run lint` after any modifications.
 
@@ -31,9 +31,9 @@ Run `mise run format` and `mise run lint` after any modifications.
   - `.config/copilot/`: Copilot agent definitions, skills, hooks, and config
   - Other tool configs follow the same one-directory-per-tool pattern
 - `.claude/`: Claude Code runtime directory (settings.json, agents, commands/)
-- `.mise/`: File-based mise task scripts that need real args or non-trivial logic
-  (e.g. `setup`, `test`); simpler tasks like format/lint are defined inline in
-  `mise.toml` `[tasks]`
+- `mise.toml`: Tool versions and inline task definitions (`setup`, `format`,
+  `lint`, `test`); tasks that need a real script go in `scripts/` and are
+  referenced from `mise.toml` (none currently)
 - `docs/`: Design documents and ADRs
 - `lib/`: Shared shell libraries sourced by setup scripts (e.g. `setup-common.sh`)
 - `tests/`: Test suites — pytest (hook scripts, repository integrity) and bats

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,15 @@ uv = "0.11.26"
 [env]
 _.file = ".env"
 
+[tasks.setup]
+description = "lefthook の git hook をインストール"
+run = '''
+# git worktree においては、ルートリポジトリ側で lefthook が設定されていればいいのでスキップ
+if [ -d ".git" ]; then
+  lefthook install
+fi
+'''
+
 [tasks."format:sh"]
 description = "shfmt でシェルスクリプトを整形"
 usage = '''
@@ -94,3 +103,15 @@ uv run ruff check -- "$@"
 [tasks.lint]
 description = "全ファイルを検査"
 depends = ["lint:sh", "lint:md", "lint:py"]
+
+[tasks."test:py"]
+description = "pytest で Python テストを実行"
+run = "uv run pytest"
+
+[tasks."test:sh"]
+description = "bats でシェルテストを実行"
+run = "bats tests/"
+
+[tasks.test]
+description = "全テストを実行"
+depends = ["test:py", "test:sh"]

--- a/tests/setup_common.bats
+++ b/tests/setup_common.bats
@@ -47,6 +47,12 @@ setup() {
 
 # --- create_hardlink ---
 
+# Reads a file's inode number. Portable across GNU stat (Linux, `-c`) and
+# BSD stat (macOS, `-f`).
+get_inode() {
+  stat -c %i "$1" 2>/dev/null || stat -f %i "$1"
+}
+
 @test "create_hardlink: creates a hard link from src to dst" {
   local src="$BATS_TEST_TMPDIR/src_file"
   local dst="$BATS_TEST_TMPDIR/dst_link"
@@ -58,8 +64,8 @@ setup() {
   [ ! -L "$dst" ]
   # Hard link shares inode
   local src_inode dst_inode
-  src_inode=$(stat -c %i "$src")
-  dst_inode=$(stat -c %i "$dst")
+  src_inode=$(get_inode "$src")
+  dst_inode=$(get_inode "$dst")
   [ "$src_inode" = "$dst_inode" ]
 }
 
@@ -72,8 +78,8 @@ setup() {
   [ "$status" -eq 0 ]
   [ -e "$dst" ]
   local src_inode dst_inode
-  src_inode=$(stat -c %i "$src")
-  dst_inode=$(stat -c %i "$dst")
+  src_inode=$(get_inode "$src")
+  dst_inode=$(get_inode "$dst")
   [ "$src_inode" = "$dst_inode" ]
 }
 
@@ -83,14 +89,14 @@ setup() {
   echo "content" >"$src"
   echo "existing" >"$dst"
   local original_inode
-  original_inode=$(stat -c %i "$dst")
+  original_inode=$(get_inode "$dst")
 
   run create_hardlink "$src" "$dst"
   [ "$status" -eq 0 ]
   [[ "$output" == *"already exist"* ]]
   # dst unchanged: same inode, same content
   local dst_inode
-  dst_inode=$(stat -c %i "$dst")
+  dst_inode=$(get_inode "$dst")
   [ "$dst_inode" = "$original_inode" ]
   [ "$(cat "$dst")" = "existing" ]
 }


### PR DESCRIPTION
## Related URLs

close #279 

## Changes
- setup.sh を mise.toml の [tasks.setup] インライン定義へ移行し .mise/tasks/setup.sh を削除
- test.sh を test:py (pytest) / test:sh (bats) のサブタスクへ分割し test は depends で集約、.mise/tasks/test.sh を削除
- AGENTS.md / standards-mise / copilot-instructions.md の .mise 参照をインライン定義前提へ更新
- bats テストの inode 取得を GNU/BSD 両対応にし macOS でも通るよう修正

## Confirmation Results
- mise tasks ls で setup / test / test:py / test:sh が表示されることを確認
- mise run test でpytest 410件と bats 11件が成功
- mise run setup / mise run format / mise run lint が成功
- サブエージェントによる全ブランチレビューで Ready to merge = Yes(Critical/Important 0件)

## Review Points
- test を depends 化したことで pytest と bats が並列実行になる(逐次から変更)。両者は独立のため問題ない想定
- test:py は旧 test.sh の pytest "$@" 引数転送を廃止(個別実行時は mise run test:py -k foo で代替可能)

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->