### PR TITLE
style: shfmt で fzf.bash と credential-gh-helper のインデントを正規化

### DIFF
--- a/.config/fzf/fzf.bash
+++ b/.config/fzf/fzf.bash
@@ -19,59 +19,59 @@ alias ffghq='cd $(find ${SOURCE_ROOT:-$HOME/src} -follow  -maxdepth ${FFGHQ_MAXD
 # find-in-file - usage: fif <searchTerm>
 # Ref: https://github.com/junegunn/fzf/wiki/examples#searching-file-contents
 fif() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
-	rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
+  rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # find in file with hidden files.
 # find-in-file-with-hidden-file - usage: fifh <searchTerm>
 fifh() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
-	rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
+  rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # Open the selected file with the default editor
 fo() {
-	local file
-	file=$(fif "")
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fif "")
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # Find file with hidden, and open the selected file with the default editor
 foh() {
-	local file
-	file=$(fifh "")
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fifh "")
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-and-open-it - usage: fog <searchTerm>
 fog() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
 
-	local file
-	file=$(fif $@)
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fif $@)
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-with-hidden-file-and-open-it - usage: fog <searchTerm>
 fogh() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
 
-	local file
-	file=$(fifh $@)
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fifh $@)
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }

--- a/.config/git/credential-gh-helper
+++ b/.config/git/credential-gh-helper
@@ -3,15 +3,15 @@
 set -euo pipefail
 
 function GH_WITH_TOKEN() {
-	local -a ENV_VARS=()
-	if [ "$(uname)" = "Linux" ] && [ -z "${GH_TOKEN:-}" ] && type pass >/dev/null 2>&1; then
-		ENV_VARS+=(
-			"GH_TOKEN=$(pass show github/token 2>/dev/null)"
-		)
-	fi
-	readonly ENV_VARS
+  local -a ENV_VARS=()
+  if [ "$(uname)" = "Linux" ] && [ -z "${GH_TOKEN:-}" ] && type pass >/dev/null 2>&1; then
+    ENV_VARS+=(
+      "GH_TOKEN=$(pass show github/token 2>/dev/null)"
+    )
+  fi
+  readonly ENV_VARS
 
-	env ${ENV_VARS[@]+"${ENV_VARS[@]}"} gh auth git-credential "$@"
+  env ${ENV_VARS[@]+"${ENV_VARS[@]}"} gh auth git-credential "$@"
 }
 
 GH_WITH_TOKEN "$@"


### PR DESCRIPTION
## Related URLs

related #280

## Changes
- .config/fzf/fzf.bash のタブインデントを shfmt (-i 2 -ci) の 2 スペースへ正規化
- .config/git/credential-gh-helper のタブインデントを同様に正規化

## Confirmation Results
- mise run format による変更が上記 2 ファイルのみであることを確認
- git show -w で差分が空白のみ(ロジック変更なし)であることを確認
- mise run lint が sh/md/py すべてクリーンにパス

## Review Points
- shfmt の設定 (-i 2 -ci) に沿った既存ドリフトの解消のみで、挙動変更はなし

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->

Issue #279 の作業中に検知した既存の書式ドリフトを、当該 PR のスコープから切り離して独立整形したもの。