### PR TITLE
ci: format 崩れ検出を CI に追加

### DIFF
--- a/.config/fzf/fzf.bash
+++ b/.config/fzf/fzf.bash
@@ -19,59 +19,59 @@ alias ffghq='cd $(find ${SOURCE_ROOT:-$HOME/src} -follow  -maxdepth ${FFGHQ_MAXD
 # find-in-file - usage: fif <searchTerm>
 # Ref: https://github.com/junegunn/fzf/wiki/examples#searching-file-contents
 fif() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
-	rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
+  rg --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # find in file with hidden files.
 # find-in-file-with-hidden-file - usage: fifh <searchTerm>
 fifh() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
-	rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
+  rg --hidden --files-with-matches -i --no-messages "$1" | fzf --preview "highlight -O ansi -l {} 2> /dev/null | rg --colors 'match:bg:yellow' --ignore-case --pretty --context 10 '$1' || rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 # Open the selected file with the default editor
 fo() {
-	local file
-	file=$(fif "")
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fif "")
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # Find file with hidden, and open the selected file with the default editor
 foh() {
-	local file
-	file=$(fifh "")
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fifh "")
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-and-open-it - usage: fog <searchTerm>
 fog() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
 
-	local file
-	file=$(fif $@)
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fif $@)
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }
 
 # combine find in file and file open.
 # find-in-file-with-hidden-file-and-open-it - usage: fog <searchTerm>
 fogh() {
-	if [ ! "$#" -gt 0 ]; then
-		echo "Need a string to search for!"
-		return 1
-	fi
+  if [ ! "$#" -gt 0 ]; then
+    echo "Need a string to search for!"
+    return 1
+  fi
 
-	local file
-	file=$(fifh $@)
-	if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
+  local file
+  file=$(fifh $@)
+  if [ -n "$file" ]; then ${EDITOR:-vim} $file; fi
 }

--- a/.config/git/credential-gh-helper
+++ b/.config/git/credential-gh-helper
@@ -3,15 +3,15 @@
 set -euo pipefail
 
 function GH_WITH_TOKEN() {
-	local -a ENV_VARS=()
-	if [ "$(uname)" = "Linux" ] && [ -z "${GH_TOKEN:-}" ] && type pass >/dev/null 2>&1; then
-		ENV_VARS+=(
-			"GH_TOKEN=$(pass show github/token 2>/dev/null)"
-		)
-	fi
-	readonly ENV_VARS
+  local -a ENV_VARS=()
+  if [ "$(uname)" = "Linux" ] && [ -z "${GH_TOKEN:-}" ] && type pass >/dev/null 2>&1; then
+    ENV_VARS+=(
+      "GH_TOKEN=$(pass show github/token 2>/dev/null)"
+    )
+  fi
+  readonly ENV_VARS
 
-	env ${ENV_VARS[@]+"${ENV_VARS[@]}"} gh auth git-credential "$@"
+  env ${ENV_VARS[@]+"${ENV_VARS[@]}"} gh auth git-credential "$@"
 }
 
 GH_WITH_TOKEN "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,15 @@ jobs:
 
       - name: Run Test
         run: mise run test
+
+  format:
+    runs-on: ubuntu-latest
+    env:
+      MISE_IGNORED_CONFIG_PATHS: ${{ github.workspace }}/.config/mise/config-mac.toml:${{ github.workspace }}/.config/mise/config-linux.toml
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+
+      - name: Run Format Check
+        run: mise run format:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Platform-specific setup scripts follow the `setup_*.sh` pattern; update scripts 
 
 ## CI
 
-The CI workflow (`.github/workflows/ci.yml`) runs `mise run lint` and `mise run test`
-as parallel jobs.
+The CI workflow (`.github/workflows/ci.yml`) runs `mise run lint`, `mise run test`, and
+`mise run format:check` as parallel jobs.
 Platform-specific mise configs are loaded only via symlinks created by `setup_*.sh` scripts,
 so they are not present in the CI environment.

--- a/mise.toml
+++ b/mise.toml
@@ -14,96 +14,76 @@ uv = "0.11.26"
 _.file = ".env"
 
 [tasks."format:sh"]
-description = "shfmt でシェルスクリプトを整形"
+description = "shfmt でシェルスクリプトを整形（--check で崩れを検査）"
 usage = '''
 arg "[files]" var=#true
+flag "--check"
 '''
 run = '''
 eval "set -- ${usage_files:-'./'}"
-shfmt -w -i 2 -ci "$@"
+if [ -n "${usage_check:-}" ]; then
+  shfmt -d -i 2 -ci "$@"
+else
+  shfmt -w -i 2 -ci "$@"
+fi
 '''
 
 [tasks."format:toml"]
-description = "taplo で TOML を整形"
+description = "taplo で TOML を整形（--check で崩れを検査）"
 usage = '''
 arg "[files]" var=#true
+flag "--check"
 '''
 run = '''
 eval "set -- ${usage_files:-'**/*.toml'}"
-taplo format "$@"
+if [ -n "${usage_check:-}" ]; then
+  taplo format --check "$@"
+else
+  taplo format "$@"
+fi
 '''
 
 [tasks."format:md"]
-description = "prettier で Markdown を整形"
+description = "prettier で Markdown を整形（--check で崩れを検査）"
 usage = '''
 arg "[files]" var=#true
+flag "--check"
 '''
 run = '''
 eval "set -- ${usage_files:-'**/*.md'}"
-prettier --write "$@"
+if [ -n "${usage_check:-}" ]; then
+  prettier --check "$@"
+else
+  prettier --write "$@"
+fi
 '''
 
 [tasks."format:py"]
-description = "ruff で Python を整形"
+description = "ruff で Python を整形（--check で崩れを検査）"
 usage = '''
 arg "[files]" var=#true
+flag "--check"
 '''
 run = '''
 eval "set -- ${usage_files:-.}"
-uv run ruff format -- "$@"
+if [ -n "${usage_check:-}" ]; then
+  uv run ruff format --check -- "$@"
+else
+  uv run ruff format -- "$@"
+fi
 '''
 
 [tasks.format]
 description = "全ファイルを整形"
 depends = ["format:sh", "format:toml", "format:md", "format:py"]
 
-[tasks."format:check:sh"]
-description = "shfmt でシェルスクリプトの整形崩れを検査"
-usage = '''
-arg "[files]" var=#true
-'''
-run = '''
-eval "set -- ${usage_files:-'./'}"
-shfmt -d -i 2 -ci "$@"
-'''
-
-[tasks."format:check:toml"]
-description = "taplo で TOML の整形崩れを検査"
-usage = '''
-arg "[files]" var=#true
-'''
-run = '''
-eval "set -- ${usage_files:-'**/*.toml'}"
-taplo format --check "$@"
-'''
-
-[tasks."format:check:md"]
-description = "prettier で Markdown の整形崩れを検査"
-usage = '''
-arg "[files]" var=#true
-'''
-run = '''
-eval "set -- ${usage_files:-'**/*.md'}"
-prettier --check "$@"
-'''
-
-[tasks."format:check:py"]
-description = "ruff で Python の整形崩れを検査"
-usage = '''
-arg "[files]" var=#true
-'''
-run = '''
-eval "set -- ${usage_files:-.}"
-uv run ruff format --check -- "$@"
-'''
-
 [tasks."format:check"]
 description = "全ファイルの整形崩れを検査"
 depends = [
-  "format:check:sh",
-  "format:check:toml",
-  "format:check:md",
-  "format:check:py",
+  "format:sh --check",
+  "format:toml --check",
+  "format:md --check",
+  "format:py --check",
 ]
 
 # shellcheck はフォルダや glob 指定を受け付けず、対象ファイルを明示的に渡す必要がある。

--- a/mise.toml
+++ b/mise.toml
@@ -57,6 +57,55 @@ uv run ruff format -- "$@"
 description = "全ファイルを整形"
 depends = ["format:sh", "format:toml", "format:md", "format:py"]
 
+[tasks."format:check:sh"]
+description = "shfmt でシェルスクリプトの整形崩れを検査"
+usage = '''
+arg "[files]" var=#true
+'''
+run = '''
+eval "set -- ${usage_files:-'./'}"
+shfmt -d -i 2 -ci "$@"
+'''
+
+[tasks."format:check:toml"]
+description = "taplo で TOML の整形崩れを検査"
+usage = '''
+arg "[files]" var=#true
+'''
+run = '''
+eval "set -- ${usage_files:-'**/*.toml'}"
+taplo format --check "$@"
+'''
+
+[tasks."format:check:md"]
+description = "prettier で Markdown の整形崩れを検査"
+usage = '''
+arg "[files]" var=#true
+'''
+run = '''
+eval "set -- ${usage_files:-'**/*.md'}"
+prettier --check "$@"
+'''
+
+[tasks."format:check:py"]
+description = "ruff で Python の整形崩れを検査"
+usage = '''
+arg "[files]" var=#true
+'''
+run = '''
+eval "set -- ${usage_files:-.}"
+uv run ruff format --check -- "$@"
+'''
+
+[tasks."format:check"]
+description = "全ファイルの整形崩れを検査"
+depends = [
+  "format:check:sh",
+  "format:check:toml",
+  "format:check:md",
+  "format:check:py",
+]
+
 # shellcheck はフォルダや glob 指定を受け付けず、対象ファイルを明示的に渡す必要がある。
 # そのため他タスクのようにツール自身の探索へ任せられず、git ls-files で一覧を生成している。
 [tasks."lint:sh"]


### PR DESCRIPTION
## Related URLs
https://github.com/iimuz/dotfiles/issues/281

## Changes
- mise に `format:check` と `format:check:{sh,toml,md,py}` タスクを追加(整形崩れを検査)
- CI に `format` ジョブを追加し `mise run format:check` を実行(lint/test と並列)
- 既存の整形崩れ(.config/fzf/fzf.bash, .config/git/credential-gh-helper のタブインデント)を2スペースへ整形
- AGENTS.md の CI 節を lint/test/format の3ジョブ構成へ更新

## Confirmation Results
- mise run format:check (sh/toml/py) PASS、tracked な Markdown も prettier clean
- mise run lint PASS
- mise run test PASS (pytest 410/410, bats 11/11)
- whole-branch レビュー APPROVED(既存 format タスク/CI ジョブと同一イディオム・pin を確認)

## Review Points
- Issue #281 の literal 要求(lint/test の CI 実行)は調査の結果すでに実装済みのため、関連改善として format 崩れ検出を追加
- format:check タスクは既存 format タスクと同一 glob を踏襲。未追跡の scratch(docs/tmp 等)はローカルでのみ prettier 誤検出となるが、CI は committed ファイルのみのため無影響
- style コミットはインデントのみ(タブ→2スペース)でロジック変更なし

## Limitations
- format ジョブは検出のみで自動修正は行わない(修正はローカルで mise run format を実行)