### PR TITLE
feat: CI 通過による非メジャー更新の自動マージを有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,12 @@ jobs:
 
       - name: Run Format Check
         run: mise run format:check
+
+  status-check:
+    if: always()
+    needs: [lint, test, format]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs passed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: mise run format:check
 
   status-check:
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [lint, test, format]
     runs-on: ubuntu-latest
     steps:

--- a/docs/adr/0003-ci-gated-automerge.md
+++ b/docs/adr/0003-ci-gated-automerge.md
@@ -1,0 +1,53 @@
+---
+id: "0003"
+status: Accepted
+date: 2026-07-25
+supersedes: []
+---
+
+# ADR-0003: CI 通過を条件とした自動マージ
+
+## Context
+
+Issue #282 に基づき、依存更新(Renovate)を CI(lint/test)の通過をもって自動マージ
+したい。各環境で動作させないと結果が分からないため、major 以外の更新は自動マージし、
+major 更新のみユーザーの確認後に手動でマージする方針とする。
+
+CI は `.github/workflows/ci.yml` の `lint` / `test` の2ジョブで、`pull_request` 時に
+実行される。自動マージを CI 通過でゲートするには、リポジトリの auto-merge 有効化と、
+master のブランチ保護(必須ステータスチェック)が必要になる。これらはファイル管理
+できないリポジトリ設定である。
+
+## Decision
+
+- Renovate の `platformAutomerge` を用いて GitHub ネイティブ auto-merge を使用する。
+  週次スケジュールに依存せず、CI 通過時点で GitHub 側が即マージする。
+- `renovate.json` で非メジャー(patch/minor)を automerge 対象とし、major は手動マージ
+  とする。Node.js major・Python minor(=major 相当)は従来通り手動とする。
+- master にブランチ保護を設定し、必須ステータスチェック `lint` / `test` を要求する。
+  PR を必須(承認数 0)とし、管理者もバイパス不可とする。
+
+## Consequences
+
+- 非メジャー更新は CI 通過で自動マージされ、手作業が減る。
+- major 更新は CI 通過を前提にユーザーが手動でマージする。
+- master への直接 push は不可となり、全変更が PR + CI を経由する。
+- ブランチ保護の有効化後は、本方針を導入する PR を含む全 PR で `lint` / `test` の
+  通過が必須になる。
+- GitHub 設定はファイル管理外のため、以下の手順で適用する。
+
+適用手順:
+
+    # 1. リポジトリの auto-merge を有効化
+    gh api repos/iimuz/dotfiles -X PATCH -F allow_auto_merge=true
+
+    # 2. master のブランチ保護
+    #    (必須チェック lint/test, PR 必須・承認0, 管理者も対象, strict 無効)
+    gh api -X PUT repos/iimuz/dotfiles/branches/master/protection --input - <<'JSON'
+    {
+      "required_status_checks": { "strict": false, "contexts": ["lint", "test"] },
+      "enforce_admins": true,
+      "required_pull_request_reviews": { "required_approving_review_count": 0 },
+      "restrictions": null
+    }
+    JSON

--- a/docs/adr/0003-ci-gated-automerge.md
+++ b/docs/adr/0003-ci-gated-automerge.md
@@ -9,14 +9,17 @@ supersedes: []
 
 ## Context
 
-Issue #282 に基づき、依存更新(Renovate)を CI(lint/test)の通過をもって自動マージ
+Issue #282 に基づき、依存更新(Renovate)を CI の通過をもって自動マージ
 したい。各環境で動作させないと結果が分からないため、major 以外の更新は自動マージし、
 major 更新のみユーザーの確認後に手動でマージする方針とする。
 
-CI は `.github/workflows/ci.yml` の `lint` / `test` の2ジョブで、`pull_request` 時に
-実行される。自動マージを CI 通過でゲートするには、リポジトリの auto-merge 有効化と、
-master のブランチ保護(必須ステータスチェック)が必要になる。これらはファイル管理
-できないリポジトリ設定である。
+CI は `.github/workflows/ci.yml` の `lint` / `test` / `format` の3ジョブを
+`pull_request` 時に実行する。自動マージを CI 通過でゲートするには、リポジトリの
+auto-merge 有効化と、master のブランチ保護(必須ステータスチェック)が必要になる。
+必須チェックをジョブ名で個別指定するとジョブの追加・改名で保護が漏れるため、全ジョブ
+の成否を集約する単一ジョブ `status-check` を追加し、それを必須チェックとする。
+auto-merge 有効化とブランチ保護はファイル管理できないリポジトリ設定だが、集約ジョブ
+自体は ci.yml で管理する。
 
 ## Decision
 
@@ -24,16 +27,20 @@ master のブランチ保護(必須ステータスチェック)が必要にな�
   週次スケジュールに依存せず、CI 通過時点で GitHub 側が即マージする。
 - `renovate.json` で非メジャー(patch/minor)を automerge 対象とし、major は手動マージ
   とする。Node.js major・Python minor(=major 相当)は従来通り手動とする。
-- master にブランチ保護を設定し、必須ステータスチェック `lint` / `test` を要求する。
-  PR を必須(承認数 0)とし、管理者もバイパス不可とする。
+- CI に集約ジョブ `status-check` を追加し、`lint` / `test` / `format` が全て成功した
+  ときのみ成功する(`if: always()` と `needs` の結果検査で判定)。master のブランチ保護
+  では、この `status-check` のみを必須ステータスチェックとして要求する。PR を必須
+  (承認数 0)とし、管理者もバイパス不可とする。
 
 ## Consequences
 
 - 非メジャー更新は CI 通過で自動マージされ、手作業が減る。
 - major 更新は CI 通過を前提にユーザーが手動でマージする。
 - master への直接 push は不可となり、全変更が PR + CI を経由する。
-- ブランチ保護の有効化後は、本方針を導入する PR を含む全 PR で `lint` / `test` の
-  通過が必須になる。
+- ブランチ保護の有効化後は、本方針を導入する PR を含む全 PR で `status-check`
+  (= `lint` / `test` / `format` の全通過)が必須になる。
+- CI ジョブを追加・改名しても、必須チェックは集約ジョブ `status-check` のままでよく、
+  ブランチ保護の再設定は不要(集約ジョブの `needs` を更新すればよい)。
 - GitHub 設定はファイル管理外のため、以下の手順で適用する。
 
 適用手順:
@@ -42,10 +49,10 @@ master のブランチ保護(必須ステータスチェック)が必要にな�
     gh api repos/iimuz/dotfiles -X PATCH -F allow_auto_merge=true
 
     # 2. master のブランチ保護
-    #    (必須チェック lint/test, PR 必須・承認0, 管理者も対象, strict 無効)
+    #    (必須チェック status-check, PR 必須・承認0, 管理者も対象, strict 無効)
     gh api -X PUT repos/iimuz/dotfiles/branches/master/protection --input - <<'JSON'
     {
-      "required_status_checks": { "strict": false, "contexts": ["lint", "test"] },
+      "required_status_checks": { "strict": false, "contexts": ["status-check"] },
       "enforce_admins": true,
       "required_pull_request_reviews": { "required_approving_review_count": 0 },
       "restrictions": null

--- a/docs/adr/0003-ci-gated-automerge.md
+++ b/docs/adr/0003-ci-gated-automerge.md
@@ -28,7 +28,7 @@ auto-merge 有効化とブランチ保護はファイル管理できないリポ
 - `renovate.json` で非メジャー(patch/minor)を automerge 対象とし、major は手動マージ
   とする。Node.js major・Python minor(=major 相当)は従来通り手動とする。
 - CI に集約ジョブ `status-check` を追加し、`lint` / `test` / `format` が全て成功した
-  ときのみ成功する(`if: always()` と `needs` の結果検査で判定)。master のブランチ保護
+  ときのみ成功する(`if: !cancelled()` と `needs` の結果検査で判定)。master のブランチ保護
   では、この `status-check` のみを必須ステータスチェックとして要求する。PR を必須
   (承認数 0)とし、管理者もバイパス不可とする。
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:best-practices", "helpers:pinGitHubActionDigests"],
   "ignorePresets": ["security:minimumReleaseAgeNpm"],
   "dependencyDashboard": false,
+  "platformAutomerge": true,
   "minimumReleaseAge": "14 days",
   "statusCheckNames": {
     "minimumReleaseAge": null
@@ -32,10 +33,11 @@
       "groupName": "mise tools (major)"
     },
     {
-      "description": "Group all mise minor updates into a single PR",
+      "description": "Group and automerge all mise minor updates",
       "matchManagers": ["mise"],
       "matchUpdateTypes": ["minor"],
-      "groupName": "mise tools (minor)"
+      "groupName": "mise tools (minor)",
+      "automerge": true
     },
     {
       "description": "Group and automerge all mise patch updates",
@@ -51,10 +53,11 @@
       "groupName": "github actions (major)"
     },
     {
-      "description": "Group all GitHub Actions minor updates into a single PR",
+      "description": "Group and automerge all GitHub Actions minor updates",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor"],
-      "groupName": "github actions (minor)"
+      "groupName": "github actions (minor)",
+      "automerge": true
     },
     {
       "description": "Group and automerge all GitHub Actions patch updates",


### PR DESCRIPTION
## Related URLs
- https://github.com/iimuz/dotfiles/issues/282

## Changes
- renovate.json: platformAutomerge を有効化し、mise / github-actions の minor 更新を自動マージ対象に追加
- major 更新は手動マージのまま維持(Node.js major・Python minor の特別ルールも維持)
- docs/adr/0003: CI 通過による自動マージ方針と、必要な GitHub 設定(auto-merge 有効化・master ブランチ保護)の gh api 適用手順を記録

## Confirmation Results
- renovate.json が有効な JSON であることを確認 (python3 -m json.tool)
- markdownlint: tracked な Markdown 139 ファイルで 0 error(新 ADR 含む)
- packageRules の順序を確認し、Node.js major・Python minor は enabled:false が優先され自動マージ対象外であることを確認

## Review Points
- リポジトリ設定/ブランチ保護は本 PR では適用せず ADR に手順化(適用はマージ後にユーザーが gh api で実施)
- branch protection は required_status_checks.contexts=[lint,test] の形式を使用(現行 GitHub API でも有効)

## Limitations
- 自動マージの実挙動確認は GitHub 設定適用後に Renovate PR で行う(本 PR の範囲外)
- 自動マージ対象は mise / github-actions マネージャ(既存グルーピング慣習に準拠)
- 本 Issue の完全な解決には、マージ後に ADR 記載の GitHub 設定適用が必要