### PR TITLE
feat: open markdown preview in cmux built-in browser

### DIFF
--- a/.config/nvim/lua/plugins/markdown-preview.lua
+++ b/.config/nvim/lua/plugins/markdown-preview.lua
@@ -3,6 +3,59 @@
 --
 -- Preview markdown file.
 
+-- cmux のターミナル内かどうか (notify.sh と同じく CMUX_SURFACE_ID で判定)
+local in_cmux = vim.env.CMUX_SURFACE_ID ~= nil
+
+-- BufEnter の follow で start() が再実行されても cmux コマンドを連打しないための直前 URL キャッシュ
+local last_opened_url = nil
+
+-- cmux の内蔵ブラウザでプレビュー URL を開く。
+-- 同一 workspace 内に既存のプレビュータブがあれば navigate で差し替え、
+-- なければ新規タブを開く (cmux browser open はフォーカスを奪わない)。
+local function open_in_cmux(url)
+    if url == last_opened_url then
+        return
+    end
+    local cmux_bin = vim.env.CMUX_BUNDLED_CLI_PATH or "cmux"
+    local ok, err = pcall(function()
+        local tree_result = vim.system(
+            { cmux_bin, "tree", "--json", "--workspace", vim.env.CMUX_WORKSPACE_ID },
+            { text = true }
+        ):wait()
+        assert(tree_result.code == 0, tree_result.stderr)
+        local tree = vim.json.decode(tree_result.stdout)
+        local preview_ref = nil
+        for _, win in ipairs(tree.windows or {}) do
+            for _, workspace in ipairs(win.workspaces or {}) do
+                for _, pane in ipairs(workspace.panes or {}) do
+                    for _, surface in ipairs(pane.surfaces or {}) do
+                        if
+                            surface.type == "browser"
+                            and type(surface.url) == "string"
+                            and surface.url:match("^http://127%.0%.0%.1:%d+/%?t=")
+                        then
+                            preview_ref = surface.ref
+                        end
+                    end
+                end
+            end
+        end
+        local cmd
+        if preview_ref then
+            cmd = { cmux_bin, "browser", preview_ref, "navigate", url }
+        else
+            cmd = { cmux_bin, "browser", "open", url }
+        end
+        local open_result = vim.system(cmd, { text = true }):wait()
+        assert(open_result.code == 0, open_result.stderr)
+    end)
+    if not ok then
+        vim.notify("MarkdownPreview: cmux open failed: " .. tostring(err), vim.log.levels.WARN)
+        return
+    end
+    last_opened_url = url
+end
+
 return {
     "selimacerbas/markdown-preview.nvim",
     lazy = true,
@@ -11,9 +64,17 @@ return {
     ft = { "markdown" },
     dependencies = { "selimacerbas/live-server.nvim" },
     config = function()
-        require("markdown_preview").setup({
+        local opts = {
             scroll_sync = false, -- iamcco 版の disable_sync_scroll = 1 に相当
-        })
+        }
+        if in_cmux then
+            -- cmux 内では workspace ごとにプレビューを分離するため multi にし、
+            -- 既定のブラウザ起動を止めて内蔵ブラウザで開く (issue #300)
+            opts.instance_mode = "multi"
+            opts.open_browser = false
+            opts.hooks = { on_start = open_in_cmux }
+        end
+        require("markdown_preview").setup(opts)
         vim.api.nvim_create_autocmd("BufEnter", {
             group = vim.api.nvim_create_augroup("MarkdownPreviewFollow", { clear = true }),
             callback = function(ev)


### PR DESCRIPTION
## Related URLs
Closes #300

## Changes
- detect when neovim runs inside a cmux terminal via CMUX_SURFACE_ID
- switch markdown-preview.nvim to instance_mode = "multi" and open_browser = false inside cmux, so each workspace gets its own preview server
- add hooks.on_start to open the preview via the cmux CLI (cmux browser open / navigate), reusing an existing preview tab in the same workspace instead of creating a new one every time
- outside cmux, behavior is unchanged (system browser, takeover mode)

## Confirmation Results
- nvim -l syntax check passed
- mise run format and mise run lint passed
- verified live inside a cmux terminal: MarkdownPreview opens a browser tab in the same cmux workspace; re-running it reuses the existing tab (browser surface count stayed at 2 before/after) instead of opening a new one

## Review Points
- the browser-surface lookup in open_in_cmux (cmux tree --json) matches on URL pattern http://127.0.0.1:<port>/?t=<token>; if multiple such tabs exist in a workspace it picks the last one enumerated, not necessarily the most recent

## Limitations
- per-workspace separation relies on cmux workspace boundaries; running multiple nvim instances in the same workspace still share the tab-reuse logic (last preview wins)
- not verified: separate cmux workspaces get independent previews (single-workspace test only)