### PR TITLE
docs: add comment format rules to gh-ops skill

### DIFF
--- a/.config/claude/skills/gh-ops/SKILL.md
+++ b/.config/claude/skills/gh-ops/SKILL.md
@@ -18,6 +18,11 @@ description: >
   for pre-write content approval
 - Default language is English unless user explicitly requests otherwise
 - On script validation error or API failure: show raw error, stop
+- When referencing issues or PRs in body text, write links as `#{number}`;
+  do not use raw URLs
+- When referencing another repository's issue or PR, use the
+  `{owner}/{repository}#{number}` format
+- Use Mermaid for diagrams in body text
 
 ## Routing
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ temp/
 
 docs/planning.md
 __pycache__/
+
+# superpowers work-in-progress artifacts (posted to PR comments, not committed)
+.superpowers/
+docs/superpowers/


### PR DESCRIPTION
## Related URLs
- resolves #302

## Changes
- append link (#{number}, {owner}/{repository}#{number}) and Mermaid diagram rules to gh-ops SKILL.md Global Constraints
- gitignore superpowers work-in-progress artifacts (docs/superpowers/, .superpowers/)

## Confirmation Results
- mise run format
- mise run lint

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->