### PR TITLE
feat: show rate-limit reset info in RunCat Neo metrics

### DIFF
--- a/.config/claude/statusline.py
+++ b/.config/claude/statusline.py
@@ -71,10 +71,21 @@ def extract_percentages(payload: dict) -> tuple[float | None, float | None]:
     return _as_float(five), _as_float(seven)
 
 
-def _metric_row(title: str, pct: float) -> dict:
+def extract_resets_at(payload: dict) -> tuple[float | None, float | None]:
+    """Return (five_hour, seven_day) resets_at epoch-second floats, or None if absent."""
+    rate_limits = payload.get("rate_limits") or {}
+    five = (rate_limits.get("five_hour") or {}).get("resets_at")
+    seven = (rate_limits.get("seven_day") or {}).get("resets_at")
+    return _as_float(five), _as_float(seven)
+
+
+def _metric_row(title: str, pct: float, suffix: str | None = None) -> dict:
+    formatted = f"{pct:.1f}%"
+    if suffix:
+        formatted = f"{formatted} ({suffix})"
     return {
         "title": title,
-        "formattedValue": f"{pct:.1f}%",
+        "formattedValue": formatted,
         "normalizedValue": round(_clamp01(pct / 100.0), 4),
     }
 
@@ -160,13 +171,18 @@ def build_output(
     seven: float | None,
     cost: float | None,
     now: datetime,
+    five_resets_at: object = None,
+    seven_resets_at: object = None,
 ) -> dict:
-    """Build the RunCat Neo custom-metrics dict from the three signals."""
+    """Build the RunCat Neo custom-metrics dict from the usage signals."""
     metrics: list[dict] = []
     if five is not None:
-        metrics.append(_metric_row("5h", five))
+        suffix = None
+        if _is_number(five_resets_at):
+            suffix = format_reset_delta(five_resets_at - now.timestamp())
+        metrics.append(_metric_row("5h", five, suffix))
     if seven is not None:
-        metrics.append(_metric_row("7d", seven))
+        metrics.append(_metric_row("7d", seven, format_reset_datetime(seven_resets_at)))
     cost_text = format_cost(cost)
     if cost_text is not None:
         metrics.append({"title": "Cost", "formattedValue": cost_text})
@@ -328,9 +344,13 @@ def main(argv: list[str]) -> None:
     if sys.platform == "darwin":
         with contextlib.suppress(Exception):
             five, seven = extract_percentages(payload)
+            five_resets_at, seven_resets_at = extract_resets_at(payload)
             maybe_spawn_refresh(now)
             cost, _ = cost_from_cache(read_json_file(COST_CACHE_FILE), now, COST_TTL_SECONDS)
-            atomic_write_json(OUT_FILE, build_output(five, seven, cost, now))
+            atomic_write_json(
+                OUT_FILE,
+                build_output(five, seven, cost, now, five_resets_at, seven_resets_at),
+            )
     try:
         line = build_statusline(payload, time.time())
     except Exception:

--- a/.config/claude/statusline.py
+++ b/.config/claude/statusline.py
@@ -30,7 +30,7 @@ import shutil
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from pathlib import Path
 
 TITLE = "Claude Code"
@@ -101,6 +101,17 @@ def format_reset_delta(seconds: object) -> str | None:
     if hours > 0:
         return f"{hours}h{minutes}m"
     return f"{minutes}m"
+
+
+def format_reset_datetime(resets_at: object, tz: tzinfo | None = None) -> str | None:
+    """Format an epoch-seconds reset time as ``MM/DD HH:MM`` in tz (local when None)."""
+    if isinstance(resets_at, bool) or not isinstance(resets_at, (int, float)):
+        return None
+    try:
+        dt = datetime.fromtimestamp(resets_at, tz=timezone.utc).astimezone(tz)
+    except (OverflowError, OSError, ValueError):
+        return None
+    return dt.strftime("%m/%d %H:%M")
 
 
 def _is_number(value: object) -> bool:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -7,6 +7,7 @@ from config.claude.statusline import (
     build_statusline,
     cost_from_cache,
     extract_percentages,
+    extract_resets_at,
     format_cost,
     format_reset_datetime,
     format_reset_delta,
@@ -77,6 +78,62 @@ class TestBuildOutput:
         out = build_output(150.0, -10.0, None, NOW)
         assert out["metrics"][0]["normalizedValue"] == 1.0
         assert out["metrics"][1]["normalizedValue"] == 0.0
+
+
+FIVE_RESETS_AT = NOW.timestamp() + 1 * 3600 + 23 * 60
+SEVEN_RESETS_AT = datetime(2026, 7, 25, 3, 30, tzinfo=timezone.utc).timestamp()
+
+
+class TestBuildOutputResets:
+    def test_five_hour_includes_remaining_time(self) -> None:
+        out = build_output(42.0, None, None, NOW, five_resets_at=FIVE_RESETS_AT)
+        assert out["metrics"][0]["formattedValue"] == "42.0% (1h23m)"
+
+    def test_seven_day_includes_reset_datetime(self) -> None:
+        out = build_output(None, 63.0, None, NOW, seven_resets_at=SEVEN_RESETS_AT)
+        expected = (
+            datetime.fromtimestamp(SEVEN_RESETS_AT, tz=timezone.utc)
+            .astimezone()
+            .strftime("%m/%d %H:%M")
+        )
+        assert out["metrics"][0]["formattedValue"] == f"63.0% ({expected})"
+
+    def test_falls_back_without_resets_at(self) -> None:
+        out = build_output(16.4, 1.0, None, NOW)
+        assert out["metrics"][0]["formattedValue"] == "16.4%"
+        assert out["metrics"][1]["formattedValue"] == "1.0%"
+
+    def test_falls_back_on_unparseable_resets_at(self) -> None:
+        out = build_output(16.4, 1.0, None, NOW, five_resets_at="soon", seven_resets_at=True)
+        assert out["metrics"][0]["formattedValue"] == "16.4%"
+        assert out["metrics"][1]["formattedValue"] == "1.0%"
+
+    def test_five_hour_falls_back_on_past_resets_at(self) -> None:
+        out = build_output(42.0, None, None, NOW, five_resets_at=NOW.timestamp() - 60)
+        assert out["metrics"][0]["formattedValue"] == "42.0%"
+
+    def test_normalized_and_bar_unchanged(self) -> None:
+        out = build_output(42.0, None, None, NOW, five_resets_at=FIVE_RESETS_AT)
+        assert out["metrics"][0]["normalizedValue"] == 0.42
+        assert out["metricsBarValue"] == "42.0%"
+
+
+class TestExtractResetsAt:
+    def test_reads_both(self) -> None:
+        payload = {
+            "rate_limits": {
+                "five_hour": {"resets_at": 1_700_000_000},
+                "seven_day": {"resets_at": 1_700_400_000.5},
+            }
+        }
+        assert extract_resets_at(payload) == (1_700_000_000.0, 1_700_400_000.5)
+
+    def test_missing(self) -> None:
+        assert extract_resets_at({}) == (None, None)
+
+    def test_bool_is_ignored(self) -> None:
+        payload = {"rate_limits": {"five_hour": {"resets_at": True}}}
+        assert extract_resets_at(payload) == (None, None)
 
 
 class TestParseMonthCost:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,6 +1,6 @@
 """Tests for the RunCat Neo statusLine wrapper (pure logic)."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from config.claude.statusline import (
     build_output,
@@ -8,6 +8,7 @@ from config.claude.statusline import (
     cost_from_cache,
     extract_percentages,
     format_cost,
+    format_reset_datetime,
     format_reset_delta,
     parse_month_cost,
 )
@@ -115,6 +116,25 @@ class TestCostFromCache:
     def test_bad_timestamp(self) -> None:
         cache = {"costUsd": 12.34, "updatedAt": "nonsense"}
         assert cost_from_cache(cache, NOW, 600) == (12.34, False)
+
+
+class TestFormatResetDatetime:
+    def test_utc(self) -> None:
+        ts = datetime(2026, 8, 3, 5, 0, tzinfo=timezone.utc).timestamp()
+        assert format_reset_datetime(ts, timezone.utc) == "08/03 05:00"
+
+    def test_timezone_conversion(self) -> None:
+        ts = datetime(2026, 8, 2, 20, 0, tzinfo=timezone.utc).timestamp()
+        jst = timezone(timedelta(hours=9))
+        assert format_reset_datetime(ts, jst) == "08/03 05:00"
+
+    def test_int_epoch_seconds(self) -> None:
+        assert format_reset_datetime(0, timezone.utc) == "01/01 00:00"
+
+    def test_invalid_inputs(self) -> None:
+        assert format_reset_datetime(None, timezone.utc) is None
+        assert format_reset_datetime(True, timezone.utc) is None
+        assert format_reset_datetime("1700000000", timezone.utc) is None
 
 
 def test_format_reset_delta_minutes():


### PR DESCRIPTION
## Related URLs

close #305

## Changes
- add format_reset_datetime() to format a 7d reset epoch timestamp as local-time "MM/DD HH:MM"
- add extract_resets_at() to read five_hour/seven_day resets_at from the statusLine stdin payload
- extend build_output() so the RunCat 5h metric shows remaining time ("42.0% (1h23m)") and the 7d metric shows the reset date/time ("63.0% (08/03 05:00)")
- fall back to percentage-only formattedValue when resets_at is missing or unparseable, never raising

## Confirmation Results
- uv run pytest tests/test_statusline.py -v (all passing)
- mise run format / mise run lint / mise run test (repo-wide, all passing)
- manual stdin smoke test confirming JSON output shape

## Review Points
- 5h/7d formattedValue string format and whether it fits RunCat Neo's display width
- build_output() keyword-arg defaults preserve backward compatibility for existing callers

## Limitations
- a resets_at value already in the past is only guaranteed to fall back to percentage-only for the 5h window (via format_reset_delta); the 7d window will still render a stale date/time in that case