### PR TITLE
docs: add duplicate search, cross-repo refs, and writing style to standards-adr skill

### DIFF
--- a/.config/claude/skills/standards-adr/SKILL.md
+++ b/.config/claude/skills/standards-adr/SKILL.md
@@ -16,9 +16,12 @@ description: >-
 
 ## Create
 
-1. Find the highest ID in `docs/adr/`, increment by one.
-2. Name: `NNNN-slug.md`
-3. Copy [references/template.md](references/template.md) and fill in content.
+1. Search existing ADRs in `docs/adr/` (titles and content) for the same or an
+   overlapping decision. If one exists, update or supersede it instead of
+   creating a duplicate.
+2. Find the highest ID in `docs/adr/`, increment by one.
+3. Name: `NNNN-slug.md`
+4. Copy [references/template.md](references/template.md) and fill in content.
 
 ## Update Status
 
@@ -33,3 +36,14 @@ On supersede: Create a new ADR with old ID in `supersedes`. Set old ADR to `Supe
 On deprecate: Set old ADR to `Deprecated`.
 
 Status is the only permitted edit to an Accepted ADR.
+
+## Cross-Repository References
+
+- Same repository: refer to ADRs as `ADR-NNNN`.
+- Other repositories: refer to ADRs as `owner/repo#ADR-NNNN`.
+
+## Writing Style
+
+- Write English headings and Japanese body text.
+- Describe considered options and their trade-offs inside the Context section.
+  Do not add a separate options section.

--- a/.config/claude/skills/standards-adr/SKILL.md
+++ b/.config/claude/skills/standards-adr/SKILL.md
@@ -17,8 +17,8 @@ description: >-
 ## Create
 
 1. Search existing ADRs in `docs/adr/` (titles and content) for the same or an
-   overlapping decision. If one exists, update or supersede it instead of
-   creating a duplicate.
+   overlapping decision. If one exists, update it or ask the user to
+   supersede it instead of creating a duplicate.
 2. Find the highest ID in `docs/adr/`, increment by one.
 3. Name: `NNNN-slug.md`
 4. Copy [references/template.md](references/template.md) and fill in content.
@@ -44,6 +44,6 @@ Status is the only permitted edit to an Accepted ADR.
 
 ## Writing Style
 
-- Write English headings and Japanese body text.
+- Write section headings in English; write the ADR title and body text in Japanese.
 - Describe considered options and their trade-offs inside the Context section.
   Do not add a separate options section.


### PR DESCRIPTION
## Related URLs
- #316
- iimuz/scratchpad#2164

## Changes
- add a duplicate-check step at the top of the Create procedure in .config/claude/skills/standards-adr/SKILL.md
- add a Cross-Repository References section (ADR-NNNN same-repo, owner/repo#ADR-NNNN other-repo)
- add a Writing Style section (English headings, Japanese body; options/trade-offs stay inside Context)

## Confirmation Results
- mise run format: no unexpected diff
- mise run lint: clean
- mise run test: 451 passed + 13 ok

## Review Points

## Limitations

<!-- Describe known limitations of this change or items to be addressed in a separate PR if any -->