### PR TITLE
feat: herdr の設定を導入する

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,9 @@
+onboarding = false
+
+[theme]
+name = "tokyo-night"
+
+[keys]
+prefix = "ctrl+g"
+split_horizontal = "prefix+s"
+settings = "prefix+shift+s"

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,5 +1,8 @@
 onboarding = false
 
+[experimental]
+kitty_graphics = true
+
 [theme]
 name = "tokyo-night"
 
@@ -7,3 +10,21 @@ name = "tokyo-night"
 prefix = "ctrl+g"
 split_horizontal = "prefix+s"
 settings = "prefix+shift+s"
+
+[[keys.command]]
+key = "prefix+shift+b"
+type = "shell"
+command = '"${HERDR_BIN_PATH}" plugin pane open --plugin official.browser --entrypoint browser --placement split --direction right --focus'
+description = "open browser in right split"
+
+[[keys.command]]
+key = "prefix+ctrl+b"
+type = "shell"
+command = '"${HERDR_BIN_PATH}" plugin pane open --plugin official.browser --entrypoint browser --placement tab --focus'
+description = "open browser in new tab"
+
+[[keys.command]]
+key = "prefix+alt+b"
+type = "shell"
+command = '"${HERDR_BIN_PATH}" plugin pane open --plugin official.browser --entrypoint browser --placement overlay --focus'
+description = "open browser overlay"

--- a/.config/homebrew/Brewfile
+++ b/.config/homebrew/Brewfile
@@ -60,6 +60,7 @@ brew "cmake"
 cask "cmux"
 brew "gcc"
 cask "ghostty"
+brew "herdr"
 # brew "luarocks"  # for lazy.nvim plugin -> おそらく lua 導入で不要になっているはず
 brew "neovim"  # neovim
 brew "pkg-config"

--- a/.config/mise/config-linux.toml
+++ b/.config/mise/config-linux.toml
@@ -1,6 +1,7 @@
 [tools]
 aws-vault = "7.2.0"
 awscli = { version = "2.36.8", symlink_bins = "true" }
+bun = "1.3.14"                                            # for herdr-browser plugin
 cargo-binstall = "1.21.1"
 "cargo:tree-sitter-cli" = "0.26.8"                        # for neovim
 claude = "2.1.220"

--- a/.config/mise/config-mac.toml
+++ b/.config/mise/config-mac.toml
@@ -1,6 +1,7 @@
 [tools]
 awscli = { version = "2.36.8", symlink_bins = "true" }
 bat = "0.26.1"
+bun = "1.3.14"                                         # for herdr-browser plugin
 cargo-binstall = "1.21.1"
 "cargo:tree-sitter-cli" = "0.26.8"                     # for neovim
 claude = "2.1.220"

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -102,6 +102,10 @@ fi
 if type gpg >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/gnupg/gpg-agent.conf" "$HOME/.gnupg/gpg-agent.conf"
 fi
+# === herdr
+if type herdr >/dev/null 2>&1; then
+  create_symlink "$SCRIPT_DIR/.config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
+fi
 # === lazygit
 if type lazygit >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/lazygit/config.yml" "$HOME/.config/lazygit/config.yml"

--- a/setup_aarch64.sh
+++ b/setup_aarch64.sh
@@ -105,6 +105,7 @@ fi
 # === herdr
 if type herdr >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
+  herdr plugin install ogulcancelik/herdr-browser --yes
 fi
 # === lazygit
 if type lazygit >/dev/null 2>&1; then

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -94,6 +94,7 @@ create_symlink "$SCRIPT_DIR/.config/ghostty/config" "$HOME/.config/ghostty/confi
 # === herdr
 if type herdr >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
+  herdr plugin install ogulcancelik/herdr-browser --yes
 fi
 # === lazygit
 if type lazygit >/dev/null 2>&1; then

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -91,6 +91,10 @@ if type git >/dev/null 2>&1; then
 fi
 # === ghostty
 create_symlink "$SCRIPT_DIR/.config/ghostty/config" "$HOME/.config/ghostty/config"
+# === herdr
+if type herdr >/dev/null 2>&1; then
+  create_symlink "$SCRIPT_DIR/.config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
+fi
 # === lazygit
 if type lazygit >/dev/null 2>&1; then
   create_symlink "$SCRIPT_DIR/.config/lazygit/config.yml" "$HOME/.config/lazygit/config.yml"

--- a/update_aarch64.sh
+++ b/update_aarch64.sh
@@ -20,3 +20,7 @@ if type mise >/dev/null 2>&1; then
   mise prune -y
   mise cache clean -y
 fi
+
+if type herdr >/dev/null 2>&1; then
+  herdr plugin install ogulcancelik/herdr-browser --yes
+fi


### PR DESCRIPTION
## Related URLs
- closes #327

## Changes
- .config/herdr/config.toml を新規作成し、tmux と同様の prefix キー(ctrl+g)・横分割・テーマ(tokyo-night)を設定
- setup_mac.sh / setup_aarch64.sh に既存パターン(type ガード + create_symlink)で herdr セクションを追加
- .config/homebrew/Brewfile に herdr のインストール行を追加(setup スクリプトの type ガードを機能させるために必要)

## Confirmation Results
- mise run test で pytest 454 件 / bats 13 件が全て PASS
- mise run lint / mise run format でエラー・差分なしを確認
- herdr --default-config の出力と照合し、config.toml で使用したキー名(prefix, split_horizontal, settings)とテーマ名(tokyo-night)が有効であることを確認

## Review Points

## Limitations
- fzf popup 系の操作(tmux の bind C / o / W)や resize キー(bind -r H/J/K/L)は herdr 標準機能で代替する方針とし、対象外とした
- macOS(setup_mac.sh)と aarch64(setup_aarch64.sh)のみ対応。他プラットフォームの setup スクリプトは対象外